### PR TITLE
Fix Bug when creating user from CLI

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,3 @@
+# Bugs
+
+1) if user is deleted while logged in gives 500 (Internal Server Error).

--- a/TODO.md
+++ b/TODO.md
@@ -24,3 +24,4 @@
   their markup to latest best practices.
 - Add an option to the command line to bump the version number in API docs and
   the TOML file.
+- add verified status to user list for admins only.

--- a/TODO.md
+++ b/TODO.md
@@ -25,3 +25,4 @@
 - Add an option to the command line to bump the version number in API docs and
   the TOML file.
 - add verified status to user list for admins only.
+- allow CLI to verify unverified users.

--- a/managers/user.py
+++ b/managers/user.py
@@ -40,7 +40,11 @@ class UserManager:
         """Register a new user."""
         user_data["password"] = pwd_context.hash(user_data["password"])
         user_data["banned"] = False
-        user_data["verified"] = False
+
+        if background_tasks:
+            user_data["verified"] = False
+        else:
+            user_data["verified"] = True
 
         try:
             email_validation = validate_email(

--- a/managers/user.py
+++ b/managers/user.py
@@ -67,8 +67,8 @@ class UserManager:
             User.select().where(User.c.id == id_)
         )
 
-        email = EmailManager()
         if background_tasks:
+            email = EmailManager()
             email.template_send(
                 background_tasks,
                 EmailTemplateSchema(

--- a/managers/user.py
+++ b/managers/user.py
@@ -105,7 +105,7 @@ class UserManager:
                 status.HTTP_400_BAD_REQUEST, ErrorMessages.AUTH_INVALID
             )
 
-        if not user_do.verified:
+        if not user_do["verified"]:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST, ErrorMessages.NOT_VERIFIED
             )

--- a/managers/user.py
+++ b/managers/user.py
@@ -78,6 +78,10 @@ class UserManager:
                         "application": f"{get_settings().api_title}",
                         "user": user_data["email"],
                         "base_url": get_settings().base_url,
+                        "name": (
+                            f"{user_data['first_name']} "
+                            f"{user_data['last_name']}"
+                        ),
                         "verification": AuthManager.encode_verify_token(
                             user_do
                         ),

--- a/templates/email/welcome.html
+++ b/templates/email/welcome.html
@@ -6,9 +6,10 @@
   email, all styles must be INLINE.
 #}
 
-<p>Hello <strong>{{ user }}</strong>, welcome to <strong>{{ application }}</strong>!</p>
-<p>Please click the link below to <strong>verify your Email address</strong>. You will be unable to acces the API before doing this.</p>
+<p>Hello <strong>{{ name }}</strong>, Welcome to <strong>{{ application }}</strong>!</p>
+<p>Please click the link below to <strong>verify your Email address</strong>.
+You will be unable to access the API before doing this.</p>
 
-<a href="{{ base_url }}/verify?code={{ verification }}">{{ base_url }}/verify?code={{ verification }}</a>
+<a href="{{ base_url }}/verify?code={{ verification }}">Verify my Email!</a>
 
 <p>This code will expire after 10 minutes.</p>


### PR DESCRIPTION
Closes #39 

For the moment, set a default `background_tasks` to `None`, then test for that when registering. This allows us to not send emails when creating users from the CLI (where BackgroundTasks would be invalid anyway, and it's usually the superuser or for testing.)

