### PR TITLE
Disable the Codacy coverage upload.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           name: codecov-python-${{ matrix.python-version }}
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./coverage.xml
+#       - name: Run codacy-coverage-reporter
+#         uses: codacy/codacy-coverage-reporter-action@v1
+#         with:
+#           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+#           coverage-reports: ./coverage.xml


### PR DESCRIPTION
Disable the Codacy coverage upload.

This fails on forks and occasionally can be dodgy getting the project_key even on the main.

We still have the main code-cov service working