### PR TITLE
Fix missing openapi schema for Docs

### DIFF
--- a/api-admin
+++ b/api-admin
@@ -4,7 +4,7 @@ import typer
 from rich import print  # pylint: disable=W0622
 from rich.panel import Panel
 
-from commands import custom, db, dev, user
+from commands import custom, db, dev, docs, user
 from config.helpers import get_api_details, get_api_version
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
@@ -56,6 +56,9 @@ app.add_typer(
     custom.app, name="custom", help="Customize the Application Metadata."
 )
 app.add_typer(db.app, name="db", help="Control the Database.")
+app.add_typer(
+    docs.app, name="docs", help="Generate and upload API documentation."
+)
 
 if __name__ == "__main__":
     app()

--- a/commands/docs.py
+++ b/commands/docs.py
@@ -1,0 +1,44 @@
+"""CLI commands for generating documentation."""
+import json
+import os
+from pathlib import Path
+
+import typer
+from fastapi.openapi.utils import get_openapi
+from rich import print  # pylint: disable=W0622
+
+from main import app as main_app
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command()
+def openapi(
+    prefix: str = typer.Option("", help="Prefix for the OpenAPI schema"),
+    filename: str = typer.Option(
+        "openapi.json", help="Filename for the OpenAPI schema"
+    ),
+):
+    """Generate an OpenAPI schema from the current routes.
+
+    By default this will be stored in the project root as `openapi.json`,
+    but you can specify a prefix to store it elsewhere using the `--prefix`
+    which is in relation to the project root.
+    You can also specify a filename using `--filename`.
+    """
+    openapi_file = Path(prefix, filename)
+    print(
+        "Generating OpenAPI schema at [bold]"
+        f"{os.path.abspath(openapi_file)}[/bold]\n"
+    )
+    with open(openapi_file, "w") as f:
+        json.dump(
+            get_openapi(
+                title=main_app.title,
+                version=main_app.version,
+                openapi_version=main_app.openapi_version,
+                description=main_app.description,
+                routes=main_app.routes,
+            ),
+            f,
+        )

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -26,9 +26,46 @@ INFO     -  [12:55:29] Watching paths for changes: 'docs', 'mkdocs.yml'
 INFO     -  [12:55:29] Serving on http://127.0.0.1:9000/
 ```
 
+!!! note
+    This command will not auto-generate the OpenAPI schema, so you will need to
+    run the below command first if your schema has changed :
+
+    ```console
+    $ poe openapi
+    ```
+
 The site is still very much a work in progress, and any PR's to add information
 will be gratefully received. The planned general layout and format can be seen
 in the `mkdocs.yml` file.
+
+If you want the site to be opened to your local network (ie to test on a
+mobile or another local device), then you can use the below command :
+
+```console
+$ poe docs:serve
+```
+
+This will run the `mkdocs serve` command, but will also open the site on your
+local network. You can then access the site on your other device using the IP
+address of your machine, and the port number shown in the output of the command.
+
+## Regenerate the OpenAPI Documentation
+
+The OpenAPI schema is needed for the documentation, and can be generated from
+the existing routes. To do this, run the below command :
+
+```console
+$ ./api-admin docs openapi --prefix=docs/reference
+```
+
+For ease of use this is also run automatically when the docs are built or
+published (but not when using the `mkdocs serve` command above).
+
+You can also run the above command easier using the `poe` command :
+
+```console
+$poe openapi
+```
 
 ## Build the Documentation
 
@@ -36,7 +73,7 @@ You can create a production-ready version of the site by using the `build`
 command:
 
 ```console
-$ mkdocs build
+$ poe docs:build
 INFO     -  Cleaning site directory
 INFO     -  Building documentation to directory: /home/seapagan/data/work/own/fastapi-template/site
 INFO     -  Documentation built in 0.95 seconds
@@ -54,5 +91,8 @@ Pages](https://pages.github.com/){:target="_blank"} using the below command :
 ```console
 $ poe docs:publish
 ```
+
+This command will automatically build the docs, and then push the `site` folder
+to GitHub. It will also auto-generate the OpenAPI schema as part of the build.
 
 Note that only someone with **WRITE** access to the repository can do this.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,11 @@ build-backend = "poetry.core.masonry.api"
 [tool.poe.tasks]
 serve = "uvicorn main:app --reload"
 pre = "pre-commit run --all-files"
-"docs:publish" = "mkdocs gh-deploy"
+_publish = "mkdocs gh-deploy"
 "docs:serve" = "mkdocs serve -a 0.0.0.0:9000"
 lint = "pylint **/*.py"
+openapi = "./api-admin docs openapi --prefix=docs/reference"
+"docs:publish"= ["openapi", "_publish"]
 
 [tool.flake8]
 exclude = ["__init__.py", ".git", "migrations/versions/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,13 @@ build-backend = "poetry.core.masonry.api"
 [tool.poe.tasks]
 serve = "uvicorn main:app --reload"
 pre = "pre-commit run --all-files"
-_publish = "mkdocs gh-deploy"
-"docs:serve" = "mkdocs serve -a 0.0.0.0:9000"
 lint = "pylint **/*.py"
+_publish_docs = "mkdocs gh-deploy"
+_build_docs = "mkdocs build"
 openapi = "./api-admin docs openapi --prefix=docs/reference"
-"docs:publish"= ["openapi", "_publish"]
+"docs:publish"= ["openapi", "_publish_docs"]
+"docs:build" = ["openapi", "_build_docs"]
+"docs:serve" = "mkdocs serve -a 0.0.0.0:9000"
 
 [tool.flake8]
 exclude = ["__init__.py", ".git", "migrations/versions/*"]


### PR DESCRIPTION
The online documentation requires a valid and recent `openapi.json` file to generate the 'Interactive API Docs` page. 

This PR adds a command to the CLI to do this and some `Poe` tasks to automate it. We also update the Web docs to reflect these new commands.