### PR TITLE
Refactor versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ finished will include full usage information and how-to's.
 - [Known Bugs](#known-bugs)
 - [Who is Using this Template?](#who-is-using-this-template)
 - [Contributing](#contributing)
-  - [GitHub Discussions](#github-discussions)
+- [GitHub Discussions](#github-discussions)
 
 ## Important note on Versioning
 
@@ -219,7 +219,7 @@ here 😃.
 
 See [Contributing][contrib] for details on how to contribute to this project.
 
-### GitHub Discussions
+## GitHub Discussions
 
 I have enabled
 [Discussions](https://github.com/seapagan/fastapi-template/discussions) on this

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Partial documentation is now availiable on it's own page at
 [https://api-template.seapagan.net][doc]. This is a work in progress, and when
 finished will include full usage information and how-to's.
 
+- [Important note on Versioning](#important-note-on-versioning)
 - [Functionality](#functionality)
 - [Installation](#installation)
 - [Docker](#docker)
@@ -31,6 +32,23 @@ finished will include full usage information and how-to's.
   - [Run pre-commit manually](#run-pre-commit-manually)
   - [Contribute your work](#contribute-your-work)
   - [GitHub Discussions](#github-discussions)
+
+## Important note on Versioning
+
+This template versioning has been refactored to start from **Verison 0.4.0**.
+
+The original template was written for my own use and probably promoted to V1.0.0
+before it should have been, and there have been many updates and fixes since
+then.
+
+I will keep the old releases available for those who wish to use them (for now a
+short time). I think it's better to do this now before there are more users who
+need to update their projects to future versions.
+
+All releases from now on will also contain a Git patch to upgrade from the
+previous version. This will be in the form of a `.patch` file which can be
+applied to their project using the `git apply` command. This will be documented
+in the release notes.
 
 ## Functionality
 
@@ -67,7 +85,14 @@ following advantages to starting your own from scratch :
   address - until this is done, the user cannot user the API.
 - Docker and Compose file set up to develop and test this API using Docker
 
-The template **Requires Python 3.8.1+**
+**This template is still in very active development and is not yet ready for
+full production use. However, I am currently using it to develop my own
+projects, which include some production API's without issues. I will update the
+template as I find bugs or add new features. I will also be adding more
+documentation as I go.**
+
+The template **Requires Python 3.8.1+** or higher. It is developed under Python
+3.11.
 
 This template is free to use but I would request some accreditation. If you do
 use it in one of your applications, please put a small note in your readme

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The original template was written for my own use and probably promoted to V1.0.0
 before it should have been, and there have been many updates and fixes since
 then.
 
-I will keep the old releases available for those who wish to use them (for now a
-short time). I think it's better to do this now before there are more users who
-need to update their projects to future versions.
+I will keep the old releases available for those who wish to use them (for a
+short time). It's better to do this now before more users need to update their
+projects to future versions.
 
 All releases from now on will also contain a Git patch to upgrade from the
 previous version. This will be in the form of a `.patch` file which can be

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ finished will include full usage information and how-to's.
 - [Known Bugs](#known-bugs)
 - [Who is Using this Template?](#who-is-using-this-template)
 - [Contributing](#contributing)
-  - [Install Git Pre-Commit hooks](#install-git-pre-commit-hooks)
-  - [Run pre-commit manually](#run-pre-commit-manually)
-  - [Contribute your work](#contribute-your-work)
   - [GitHub Discussions](#github-discussions)
 
 ## Important note on Versioning
@@ -220,39 +217,7 @@ here 😃.
 
 ## Contributing
 
-Please **do** feel free to open an Issue for any bugs or issues you find, or
-even a Pull Request with solutions 😎
-
-Likewise, I am very open to new feature Pull Requests!
-
-### Install Git Pre-Commit hooks
-
-Please do this if you are intending to submit a PR. It will check commits
-locally before they are pushed up to the Repo.
-
-```console
-$ pre-commit install
-pre-commit installed at .git/hooks/pre-commit
-```
-
-This will ensure that all code meets the required linting standard before being
-committed.
-
-### Run pre-commit manually
-
-You can run these checks manually on all files using the below command :
-
-```console
-poe pre
-```
-
-### Contribute your work
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+See [Contributing][contrib] for details on how to contribute to this project.
 
 ### GitHub Discussions
 
@@ -262,3 +227,4 @@ repository, so if you have any questions, suggestions or just want to chat about
 this template, please feel free to start a discussion.
 
 [doc]:https://api-template.seapagan.net
+[contrib]:https://api-template.seapagan.net/contributing/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,6 +5,13 @@ even a Pull Request with solutions 😎
 
 Likewise, I am very open to new feature Pull Requests!
 
+## GitHub Discussions
+
+I have enabled
+[Discussions](https://github.com/seapagan/fastapi-template/discussions) on this
+repository, so if you have any questions, suggestions or just want to chat about
+this template, please feel free to start a discussion.
+
 ## Install Git Pre-Commit hooks
 
 Please do this if you are intending to submit a PR. It will check commits

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,22 @@
 !!! warning "ALPHA Status!"
     This documentation is currently **Alpha** status and I have much still to add.
 
+!!! danger "Version Refactor"
+
+    This template versioning has been refactored to start from **Verison 0.4.0**
+    . The original template was written for my own use and probably promoted to
+    V 1.0.0 before it should have been, and there have been many updates and
+    fixes since then.
+
+    I will keep the old releases available for those who wish to use them (for
+    now a short time). I think it's better to do this now before there are more
+    users who need to update their projects to future versions.
+
+    All releases from now on will also contain a Git patch to upgrade from the
+    previous version. This will be in the form of a `.patch` file which can be
+    applied to their project using the `git apply` command. This will be
+    documented in the release notes.
+
 ## Features
 
 This template is a ready-to-use boilerplate for a FastAPI project. It has the
@@ -39,6 +55,27 @@ following advantages to starting your own from scratch :
 - Docker and Compose file set up to develop and test this API using Docker
 
 The template **Requires Python 3.8.1+**
+
+## Versioning
+
+!!! important "Version 0.4.0"
+
+    This template is still in very active development and is not yet ready for
+    full production use. However, I am currently using it to develop my own
+    projects, which include some production API's without issues. I will update
+    the template as I find bugs or add new features. I will also be adding more
+    documentation as I go.
+
+This project uses [Semantic Versioning 2.0.0](https://semver.org/)
+
+Given a version number `MAJOR`.`MINOR`.`PATCH`, increment the:
+
+  1. `MAJOR` version when you make incompatible API changes
+  2. `MINOR` version when you add functionality in a backward compatible manner
+  3. `PATCH` version when you make backward compatible bug fixes
+
+Additional labels for pre-release and build metadata are available as extensions
+to the MAJOR.MINOR.PATCH format.
 
 ## Follow the Repository
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,13 @@ Given a version number `MAJOR`.`MINOR`.`PATCH`, increment the:
 Additional labels for pre-release and build metadata are available as extensions
 to the MAJOR.MINOR.PATCH format.
 
+## GitHub Discussions
+
+[Discussions](https://github.com/seapagan/fastapi-template/discussions) are
+enabled on this repository, so if you have any problems, questions, suggestions
+or just want to chat about this template, please feel free to start a
+discussion.
+
 ## Follow the Repository
 
 If you use this code in your own projects, I'd recommend at least to 'star' or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "API Template"
-version = "1.5.0"
+version = "0.4.0"
 description = "Run 'api-admin custom metadata' to change this information."
 authors = ["Grant Ramsay (seapagan) <seapagan@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Refactor the project versions to start at `0.4.0`

The original template was written for my own use and probably promoted to V1.0.0 before it should have been, and there have been many updates and fixes since then.

I will keep the old releases available for those who wish to use them (for a short time). It's better to do this now before more users need to update their projects to future versions.

All releases from now on will also contain a Git patch to upgrade from the previous version. This will be in the form of a `.patch` file which can be applied to their project using the `git apply` command. This will be documented in the release notes.