### PR TITLE
Add release version to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ The template **Requires Python 3.8.1+**
 
 ## Versioning
 
-!!! important "Current Version {{ latest-git-tag }}"
+!!! important "Current Release version is {{ latest-git-tag }}"
 
     This template is still in very active development and is not yet ready for
     full production use. However, I am currently using it to develop my own

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ The template **Requires Python 3.8.1+**
 
 ## Versioning
 
-!!! important "Version 0.4.0"
+!!! important "Current Version {{ latest-git-tag }}"
 
     This template is still in very active development and is not yet ready for
     full production use. However, I am currently using it to develop my own

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ plugins:
       supportedSubmitMethods: []
       defaultModelsExpandDepth: 0
   - git-revision-date-localized
+  - latest-git-tag
   - minify:
       minify_html: true
       minify_css: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -1827,13 +1827,13 @@ pytz = "*"
 
 [[package]]
 name = "mkdocs-latest-git-tag-plugin"
-version = "0.1.0"
+version = "0.1.1"
 description = "MkDocs plugin to get the latest git tag from the local repository"
 optional = false
 python-versions = ">=3.8.1,<4.0.0"
 files = [
-    {file = "mkdocs_latest_git_tag_plugin-0.1.0-py3-none-any.whl", hash = "sha256:bf0cabab3bf7512aaf8235d88975b5a31187daa5e4b2a005bdabbdef749c0da5"},
-    {file = "mkdocs_latest_git_tag_plugin-0.1.0.tar.gz", hash = "sha256:e8287c585b66912c4054b3d996e6f0e9519053552062122e9d811ec4f70f06ac"},
+    {file = "mkdocs_latest_git_tag_plugin-0.1.1-py3-none-any.whl", hash = "sha256:e2b5b8818b3476d3e27467215c442534c6bd7a7bf4db8e651e61b14c4047082a"},
+    {file = "mkdocs_latest_git_tag_plugin-0.1.1.tar.gz", hash = "sha256:d0fe7f31598eca2eebf588ee4096759eaff333e2b47f0e2e5b84285b50f9ed7c"},
 ]
 
 [package.dependencies]
@@ -3895,4 +3895,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "dbdcf2f2951bd3baa74aa9725ce374eff740527b555092cfb8ddea1c28d0d4b3"
+content-hash = "59e1a186bc8eca8110e847c967690203dfcacc4e824bddb572e3f6433a1761a9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1826,6 +1826,21 @@ mkdocs = ">=1.0"
 pytz = "*"
 
 [[package]]
+name = "mkdocs-latest-git-tag-plugin"
+version = "0.1.0"
+description = "MkDocs plugin to get the latest git tag from the local repository"
+optional = false
+python-versions = ">=3.8.1,<4.0.0"
+files = [
+    {file = "mkdocs_latest_git_tag_plugin-0.1.0-py3-none-any.whl", hash = "sha256:bf0cabab3bf7512aaf8235d88975b5a31187daa5e4b2a005bdabbdef749c0da5"},
+    {file = "mkdocs_latest_git_tag_plugin-0.1.0.tar.gz", hash = "sha256:e8287c585b66912c4054b3d996e6f0e9519053552062122e9d811ec4f70f06ac"},
+]
+
+[package.dependencies]
+gitpython = ">=3.1.31,<4.0.0"
+mkdocs = ">=1.4.3,<2.0.0"
+
+[[package]]
 name = "mkdocs-material"
 version = "9.1.16"
 description = "Documentation that simply works"
@@ -3880,4 +3895,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "b44536a18f601407acbc81e8dd2fbde4aad30d5f9a3f24bb6d740b5f21d20c7e"
+content-hash = "dbdcf2f2951bd3baa74aa9725ce374eff740527b555092cfb8ddea1c28d0d4b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ mock = "^5.0.2"
 faker = "^18.10.1"
 mkdocs-git-revision-date-localized-plugin = "^1.2.0"
 mkdocs-minify-plugin = "^0.6.4"
+mkdocs-latest-git-tag-plugin = "^0.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ mock = "^5.0.2"
 faker = "^18.10.1"
 mkdocs-git-revision-date-localized-plugin = "^1.2.0"
 mkdocs-minify-plugin = "^0.6.4"
-mkdocs-latest-git-tag-plugin = "^0.1.0"
+mkdocs-latest-git-tag-plugin = "^0.1.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Take the latest release tag and display this in the online documentation. 

I quickly wrote an MkDocs plugin to do this: [mkdocs-latest-git-tag-plugin](https://seapagan.github.io/mkdocs-latest-git-tag-plugin/).