### PR TITLE
Migrate startup to lifespan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ markers = [
   "unit: Unit tests",
   "integration: Integration tests",
 ]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 # source = []


### PR DESCRIPTION
The FastAPI startup event is deprecated, it is now recommended to use the 'lifespan' functionality instead