### PR TITLE
make the API an installable package and CLI command

### DIFF
--- a/app/api_admin.py
+++ b/app/api_admin.py
@@ -1,4 +1,3 @@
-#! /bin/env python
 """Run administrative tasks for the Template system."""
 from typing import Optional
 

--- a/app/commands/custom.py
+++ b/app/commands/custom.py
@@ -190,3 +190,4 @@ def metadata() -> None:
             print(f"Cannot update the pyproject.toml file : {err}")
             sys.exit(3)
         print("Done!")
+        print("\n[cyan]-> Remember to RESTART the API if it is running.\n")

--- a/app/config/helpers.py
+++ b/app/config/helpers.py
@@ -2,16 +2,20 @@
 import os
 import sys
 from dataclasses import dataclass
+from importlib import resources
 from pathlib import Path
 
 import tomli
 
 
+def get_project_root() -> Path:
+    """Return the full path of the project root."""
+    return Path(str(resources.files("app"))) / ".."
+
+
 def get_toml_path() -> Path:
     """Return the full path of the pyproject.toml."""
-    script_dir = Path(os.path.realpath(__name__)).parent
-
-    return script_dir / "pyproject.toml"
+    return get_project_root() / "pyproject.toml"
 
 
 def get_config_path() -> Path:

--- a/app/config/helpers.py
+++ b/app/config/helpers.py
@@ -1,5 +1,4 @@
 """Helper classes and functions for config use."""
-import os
 import sys
 from dataclasses import dataclass
 from importlib import resources
@@ -20,8 +19,7 @@ def get_toml_path() -> Path:
 
 def get_config_path() -> Path:
     """Return the full path of the custom config file."""
-    script_dir = Path(os.path.realpath(sys.argv[0])).parent
-    return script_dir / "app" / "config" / "metadata.py"
+    return get_project_root() / "app" / "config" / "metadata.py"
 
 
 def get_api_version() -> str:
@@ -118,7 +116,7 @@ custom_metadata = MetadataBase(
         "url": "{{ website }}",
     },
     email="{{ email }}",
-    year="{{ this_year }}"
+    year="{{ this_year }}",
 )
 
 """

--- a/app/config/helpers.py
+++ b/app/config/helpers.py
@@ -9,7 +9,7 @@ import tomli
 
 def get_project_root() -> Path:
     """Return the full path of the project root."""
-    return Path(str(resources.files("app"))) / ".."
+    return (Path(str(resources.files("app"))) / "..").resolve()
 
 
 def get_toml_path() -> Path:

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,8 +1,11 @@
 """Control the app settings, including reading from a .env file."""
 import sys
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from app.config.helpers import get_project_root
 
 try:
     from .metadata import custom_metadata
@@ -23,7 +26,10 @@ class Settings(BaseSettings):
     not be stored in the Git repository.
     """
 
-    model_config = SettingsConfigDict(env_file=".env")
+    project_root: Path = get_project_root()
+
+    env_file: str = str(project_root / ".env")
+    model_config = SettingsConfigDict(env_file=env_file)
 
     base_url: str = "http://localhost:8000"
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from rich import print  # pylint: disable=W0622
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.config.helpers import get_api_version
+from app.config.helpers import get_api_version, get_project_root
 from app.config.settings import get_settings
 from app.database.db import async_session
 from app.resources import config_error
@@ -54,7 +54,9 @@ app = FastAPI(
 )
 
 app.include_router(api_router)
-app.mount("/static", StaticFiles(directory="static"), name="static")
+
+static_dir = get_project_root() / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 # set up CORS
 cors_list = (get_settings().cors_origins).split(",")

--- a/app/resources/home.py
+++ b/app/resources/home.py
@@ -4,11 +4,13 @@ from typing import Union
 from fastapi import APIRouter, Header, Request
 from fastapi.templating import Jinja2Templates
 
-from app.config.helpers import get_api_version
+from app.config.helpers import get_api_version, get_project_root
 from app.config.settings import get_settings
 
 router = APIRouter()
-templates = Jinja2Templates(directory="app/templates")
+
+template_folder = get_project_root() / "app" / "templates"
+templates = Jinja2Templates(directory=template_folder)
 
 RootResponse = Union[dict[str, str], templates.TemplateResponse]  # type: ignore
 

--- a/docs/customization/meta.md
+++ b/docs/customization/meta.md
@@ -42,7 +42,7 @@ The `api-admin` command can also do this for you, asking for the values at the
 command line and automatically updating both files:
 
 ```console
-$ ./api-admin custom metadata
+$ api-admin custom metadata
 
 API-Template : Customize application Metadata
 

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -26,6 +26,12 @@ INFO     -  [12:55:29] Watching paths for changes: 'docs', 'mkdocs.yml'
 INFO     -  [12:55:29] Serving on http://127.0.0.1:9000/
 ```
 
+You may also run it using a `Poe` task:
+
+```console
+$ poe docs:serve
+```
+
 !!! note
     This command will not auto-generate the OpenAPI schema, so you will need to
     run the below command first if your schema has changed :
@@ -42,7 +48,7 @@ If you want the site to be opened to your local network (ie to test on a
 mobile or another local device), then you can use the below command :
 
 ```console
-$ poe docs:serve
+$ poe docs:serve:all
 ```
 
 This will run the `mkdocs serve` command, but will also open the site on your
@@ -55,7 +61,7 @@ The OpenAPI schema is needed for the documentation, and can be generated from
 the existing routes. To do this, run the below command :
 
 ```console
-$ ./api-admin docs openapi --prefix=docs/reference
+$ api-admin docs openapi --prefix=docs/reference
 ```
 
 For ease of use this is also run automatically when the docs are built or

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -8,14 +8,14 @@ used for testing the API during development. There is a built-in command to run
 this easily :
 
 ```console
-./api-admin serve
+$ api-admin serve
 ```
 
 This will by default run the server on <http://localhost:8000>, and reload after
 any change to the source code. You can add options to change this
 
 ```console
-$ ./api-admin serve --help
+$ api-admin serve --help
 
 Usage: api-admin serve [OPTIONS]
 

--- a/docs/usage/add-user.md
+++ b/docs/usage/add-user.md
@@ -10,7 +10,7 @@ optionally make them Admin at the same time:
 ## Interactively
 
 ```console
-./api-admin user create
+$ api-admin user create
 ```
 
 You will be asked for the new user's email etc, and if this should be an
@@ -49,7 +49,7 @@ options that are missing will be prompted for (except for Admin, this must be
 physically specified if wanted) :
 
 ```console
-$ ./api-admin user create --email testuser@mailserver.com -f Test -l Last -p s3cr3tpassw0rd
+$ api-admin user create --email testuser@mailserver.com -f Test -l User -p s3cr3tpassw0rd
 ```
 
 In the above case a normal user will be created. You can mix long-form

--- a/docs/usage/configuration/database.md
+++ b/docs/usage/configuration/database.md
@@ -6,7 +6,7 @@ Make sure you have [configured](dot-env.md) the database. Then
 run the following command to set it up, applying all the required migrations:
 
 ```console
-$ ./api-admin db init
+$ api-admin db init
 ```
 
 (this is the same as running `alembic upgrade head`, though it will downgrade to
@@ -19,7 +19,7 @@ will be asked for a commit message. This will create and apply the migration in
 the same step:
 
 ```console
-$ ./api-admin db revision
+$ api-admin db revision
 Enter the commit message for the revision: Added email to the users model
 
   Generating ..._added_email_to_the_users_model.py ...  done
@@ -48,7 +48,7 @@ init` again before the database is usable.
 Look at the built-in help for more details :
 
 ```console
-$ ./api-admin db --help
+$ api-admin db --help
 Usage: api-admin db [OPTIONS] COMMAND [ARGS]...
 
  Control the Database.

--- a/docs/usage/configuration/setup.md
+++ b/docs/usage/configuration/setup.md
@@ -6,6 +6,13 @@ It is always a good idea to set up dedicated Virtual Environment when you are
 developing a Python application. If you use Poetry, this will be done
 automatically for you when you run `poetry install`.
 
+!!! tip
+
+    I recommend using [Poetry](https://python-poetry.org/){:target="_blank"} for
+    this project as that is how it has been developed. Also, using Poetry will
+    automatically set up a Virtual Environment for you and install the
+    `api-admin` command (see later)
+
 Otherwise, [Pyenv](https://github.com/pyenv/pyenv){:target="_blank"} has a
 [virtualenv](https://github.com/pyenv/pyenv-virtualenv){:target="_blank"} plugin
 which is very easy to use.
@@ -26,7 +33,7 @@ dependencies. If you have Poetry installed, simply run the following to install
 all that is needed.
 
 ```console
-poetry install
+$ poetry install
 ```
 
 If you do not (or cannot) have Poetry installed, I have provided an
@@ -34,8 +41,25 @@ auto-generated `requirements.txt` in the project root which you can use as
 normal:
 
 ```console
-pip install -r requirements.txt
+$ pip install -r requirements.txt
 ```
+
+The above will install **`production`** dependencies only. If you want to
+install **`development`** dependencies as well, use the following instead:
+
+```console
+$ pip install -r requirements-dev.txt
+```
+
+!!! warning
+
+    If you are NOT using Poetry, the `api-admin` command will not be available.
+    However, you can run the same command using the following from the project
+    root:
+
+    ```console
+    $ python app/api-admin.py
+    ```
 
 I definately recommend using Poetry if you can though, it makes dealing with
 updates and conflicts very easy.
@@ -43,7 +67,7 @@ updates and conflicts very easy.
 If using poetry you now need to activate the VirtualEnv:
 
 ```console
-poetry shell
+$ poetry shell
 ```
 
 ## Install Git Pre-Commit hooks
@@ -64,5 +88,5 @@ committed.
 You can run these checks manually on all files using the below command :
 
 ```console
-poe pre
+$ poe pre
 ```

--- a/docs/usage/user-control.md
+++ b/docs/usage/user-control.md
@@ -21,7 +21,7 @@ note that any user added this was will be **automatically verified**.
 You can list all registered users in a nice table as shown below:
 
 ```console
-$ ./api-admin user list
+$ api-admin user list
 ```
 
 This will show Id, Email address, First and Last name, Role, and the Verified
@@ -37,7 +37,7 @@ and Banned Status.
 ## List a specific User
 
 ```console
-$ ./api-admin user show 23
+$ api-admin user show 23
 ```
 
 This will show the same data as above, but for only one user. You must specify
@@ -50,7 +50,7 @@ without needing to use the validation email. Useful for testing or adding Users
 you know exist.
 
 ```console
-$ ./api-admin user verify 23
+$ api-admin user verify 23
 ```
 
 ## Search for a user
@@ -63,13 +63,13 @@ Ban a User so they cannot access the API. You can also `unban` any user by
 adding the `-u` or `--unban` flag.
 
 ```console
-$ ./api-admin user ban 23
+$ api-admin user ban 23
 ```
 
 or to unban:
 
 ```console
-$ ./api-admin user ban 23 -u
+$ api-admin user ban 23 -u
 ```
 
 ## Delete a specific User
@@ -77,7 +77,7 @@ $ ./api-admin user ban 23 -u
 To remove a specific user from the API:
 
 ```console
-$ ./api-admin user delete 23
+$ api-admin user delete 23
 ```
 
 They will no longer be able to access the API, this CANNOT BE UNDONE. It's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ license = "MIT"
 readme = "README.md"
 packages = [{ include = "app", from = "." }]
 
+classifiers = ["Private :: Do Not Upload"]
+
 [tool.poetry.scripts]
 api-admin = "app.api_admin:app"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Run 'api-admin custom metadata' to change this information."
 authors = ["Grant Ramsay (seapagan) <seapagan@gmail.com>"]
 license = "MIT"
 readme = "README.md"
+packages = [{ include = "app", from = "." }]
 
+[tool.poetry.scripts]
+api-admin = "app.api_admin:app"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,4 +228,4 @@ mock_use_standalone_module = true
 [tool.coverage.run]
 # source = []
 source = ["app"]
-omit = ["*/tests/*", "app/commands/*"]
+omit = ["*/tests/*", "app/commands/*", "app/api_admin.py"]

--- a/tests/unit/test_config_helpers.py
+++ b/tests/unit/test_config_helpers.py
@@ -22,16 +22,16 @@ class TestConfigHelpers:
     def test_get_toml_path(self, mocker) -> None:
         """Test we get the correct toml path."""
         mocker.patch(
-            "app.config.helpers.os.path.realpath",
-            return_value="/test/path/script.py",
+            "app.config.helpers.resources.files",
+            return_value="/test/path/app",
         )
         assert get_toml_path() == Path("/test/path/pyproject.toml")
 
     def test_get_config_path(self, mocker) -> None:
         """Test we get the correct config path."""
         mocker.patch(
-            "app.config.helpers.os.path.realpath",
-            return_value="/test/path/script.py",
+            "app.config.helpers.resources.files",
+            return_value="/test/path/app",
         )
         assert get_config_path() == Path("/test/path/app/config/metadata.py")
 


### PR DESCRIPTION
[`NOTE: This does NOT make this into a package that can be pushed to PyPI, in fact, it specifically has the "Private :: Do Not Upload" classifier`]

Avoids a  new Poetry warning.

Poetry devs stubbornly believe that it's only used for packages despite complaints. The newest version gives a very obtrusive error-like warning if a package is not defined and '--no-root' is not specified.

This PR adds a package config to the API, which is installed in editable mode when running `poetry install`. This removes the warning and allows us to make the `api-admin` command an actual command instead of a script, which can be run from any location as long as the virtual env is active.

This is a `breaking change` for the CLI usage, but otherwise, it will be transparent to the API