### PR TITLE
Continue testing on the `api-admin custom` CLI command

### DIFF
--- a/app/commands/custom.py
+++ b/app/commands/custom.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime
 import sys
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 import asyncclick as click
 import tomli
@@ -109,16 +109,13 @@ def choose_version(current_version: str) -> str:
     return choice
 
 
-@app.command()
-def metadata() -> None:
-    """Customize the Application Metadata.
-
-    This includes the title and description displayed on the root route and
-    Documentation, Author details, Repository URL and more.
-    """
-    data = {
+def get_data() -> dict[str, Any]:
+    """Get the data from the user."""
+    return {
         "title": click.prompt(
-            "Enter your API title", type=str, default=custom_metadata.title
+            "Enter your API title",
+            type=str,
+            default=custom_metadata.title,
         ),
         "desc": click.prompt(
             "Enter the description",
@@ -148,6 +145,16 @@ def metadata() -> None:
             default=custom_metadata.contact["url"],
         ),
     }
+
+
+@app.command()
+def metadata() -> None:
+    """Customize the Application Metadata.
+
+    This includes the title and description displayed on the root route and
+    Documentation, Author details, Repository URL and more.
+    """
+    data = get_data()
 
     data["this_year"] = (
         datetime.datetime.now(tz=datetime.timezone.utc).today().year

--- a/tests/cli/test_cli_custom_command.py
+++ b/tests/cli/test_cli_custom_command.py
@@ -12,6 +12,7 @@ from app.commands.custom import (
     choose_license,
     choose_version,
     get_case_insensitive_dict,
+    get_data,
     get_licenses,
     init,
 )
@@ -23,6 +24,21 @@ class TestCLI:
 
     metadata_path = Path("/home/test/metadata.json")
     mock_get_config_path = "app.commands.custom.get_config_path"
+    home_dir = "/home/test"
+
+    test_data = {
+        "title": "Test Title",
+        "desc": "Test Description",
+        "version": "0.5.0",
+        "repo": "https://myrepo.com",
+        "license": {
+            "name": "MIT",
+            "url": "https://opensource.org/licenses/MIT",
+        },
+        "author": "test_user",
+        "email": "test_user@test.com",
+        "website": "https://mysite.com",
+    }
 
     def test_no_command_should_give_help(self, runner: CliRunner) -> None:
         """Test that running with no command should give help."""
@@ -36,12 +52,12 @@ class TestCLI:
         assert all(command in result.output for command in command_list)
 
     def test_init_function(self, fs, mocker) -> None:
-        """Test that running 'init' should create a deafult metadata."""
+        """Test that running 'init' should create a default metadata."""
         mock_get_config_path = mocker.patch(
             self.mock_get_config_path,
             return_value=self.metadata_path,
         )
-        fs.create_dir("/home/test")
+        fs.create_dir(self.home_dir)
 
         assert not self.metadata_path.exists()
 
@@ -56,7 +72,7 @@ class TestCLI:
             self.mock_get_config_path,
             return_value=self.metadata_path,
         )
-        fs.create_dir("/home/test")
+        fs.create_dir(self.home_dir)
         fs.create_file(
             self.metadata_path,
             contents='{"title": "Test Title"}',
@@ -79,7 +95,7 @@ class TestCLI:
             side_effect=OSError("File Error"),
         )
 
-        fs.create_dir("/home/test")
+        fs.create_dir(self.home_dir)
 
         with pytest.raises(typer.Exit):
             init()
@@ -90,6 +106,26 @@ class TestCLI:
         assert "File Error" in output
 
     # ----------------------- test individual functions ---------------------- #
+    def test_get_input_from_user(self, mocker) -> None:
+        """Test that running the ."""
+        test_input = (
+            "Test Title\nTest Description\n0.5.0\nhttps://myrepo.com\nMIT\ntest_user\n"
+            "test_user@test.com\nhttps://mysite.com\n\n"
+        )
+        mocker.patch.object(sys, "stdin", io.StringIO(test_input))
+
+        input_values = get_data()
+
+        assert isinstance(input_values, dict)
+        assert input_values["title"] == "Test Title"
+        assert input_values["desc"] == "Test Description"
+        assert input_values["version"] == "0.5.0"
+        assert input_values["repo"] == "https://myrepo.com"
+        assert input_values["license"]["name"] == "MIT"
+        assert input_values["author"] == "test_user"
+        assert input_values["email"] == "test_user@test.com"
+        assert input_values["website"] == "https://mysite.com"
+
     def test_get_licenses_function(self) -> None:
         """Test that running 'get_licenses' should return a list of licenses."""
         licenses = get_licenses()
@@ -138,7 +174,7 @@ class TestCLI:
 
     def test_choose_license(self, mocker, capsys) -> None:
         """Test that the choose license function works."""
-        mocker.patch.object(sys, "stdin", io.StringIO("mit\n"))
+        mock_stdin = mocker.patch.object(sys, "stdin", io.StringIO("mit\n"))
 
         license_string = ", ".join(
             [license_name["name"] for license_name in LICENCES]
@@ -152,3 +188,5 @@ class TestCLI:
 
         assert isinstance(license_choice, dict)
         assert license_choice["name"] == "MIT"
+
+        assert mock_stdin.read

--- a/tests/cli/test_cli_custom_command.py
+++ b/tests/cli/test_cli_custom_command.py
@@ -1,5 +1,6 @@
 """Test the 'api-admin custom' command."""
 import io
+import os
 import sys
 from pathlib import Path
 
@@ -66,22 +67,34 @@ class TestCLI:
 
     # ----------------------- test the 'init' function ----------------------- #
     def test_init_function(self, fs, mocker) -> None:
-        """Test that running 'init' should create a default metadata."""
+        """Test that running 'init' should create a default metadata.
+
+        We use 'os.path' to check for the existence of the file, as the
+        filesystem mock does not work with Path objects created outside of
+        the test function (though seems to work in Python >=3.10).
+        """
         mock_get_config_path = mocker.patch(
             self.mock_get_config_path,
             return_value=self.metadata_path,
         )
         fs.create_dir(self.home_dir)
 
-        assert not self.metadata_path.exists()
+        assert not os.path.exists(self.metadata_path)  # noqa: PTH110
 
         init()
 
+        print(self.metadata_path)
+
         assert mock_get_config_path.called
-        assert self.metadata_path.exists()
+        assert os.path.exists(self.metadata_path)  # noqa: PTH110
 
     def test_init_function_with_existing_metadata(self, fs, mocker) -> None:
-        """Test that running 'init' should overwrite existing metadata."""
+        """Test that running 'init' should overwrite existing metadata.
+
+        We use 'os.path' to check for the existence of the file, as the
+        filesystem mock does not work with Path objects created outside of
+        the test function (though seems to work in Python >=3.10).
+        """
         mock_get_config_path = mocker.patch(
             self.mock_get_config_path,
             return_value=self.metadata_path,
@@ -92,12 +105,12 @@ class TestCLI:
             contents='{"title": "Test Title"}',
         )
 
-        assert self.metadata_path.exists()
+        assert os.path.exists(self.metadata_path)  # noqa: PTH110
 
         init()
 
         assert mock_get_config_path.called
-        assert self.metadata_path.exists()
+        assert os.path.exists(self.metadata_path)  # noqa: PTH110
 
         with self.metadata_path.open() as file:
             assert file.read() != '{"title": "Test Title"}'

--- a/tests/cli/test_cli_custom_command.py
+++ b/tests/cli/test_cli_custom_command.py
@@ -22,9 +22,9 @@ from app.config.helpers import LICENCES
 class TestCLI:
     """Test the custom CLI commands."""
 
-    metadata_path = Path("/home/test/metadata.json")
     mock_get_config_path = "app.commands.custom.get_config_path"
-    home_dir = "/home/test"
+    home_dir = Path("/home/test")
+    metadata_path = home_dir / "metadata.json"
 
     test_data = {
         "title": "Test Title",
@@ -40,6 +40,11 @@ class TestCLI:
         "website": "https://mysite.com",
     }
 
+    test_input = (
+        "Test Title\nTest Description\n0.5.0\nhttps://myrepo.com\nMIT\ntest_user\n"
+        "test_user@test.com\nhttps://mysite.com\n\n"
+    )
+
     def test_no_command_should_give_help(self, runner: CliRunner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, ["custom"])
@@ -51,6 +56,15 @@ class TestCLI:
 
         assert all(command in result.output for command in command_list)
 
+    def test_metadata_command(
+        self, runner: CliRunner, fs, mocker, capsys
+    ) -> None:
+        """Test running the 'metadata' command.
+
+        This should modify both the metadata.py and the pyproject.toml files.
+        """
+
+    # ----------------------- test the 'init' function ----------------------- #
     def test_init_function(self, fs, mocker) -> None:
         """Test that running 'init' should create a default metadata."""
         mock_get_config_path = mocker.patch(
@@ -107,12 +121,8 @@ class TestCLI:
 
     # ----------------------- test individual functions ---------------------- #
     def test_get_input_from_user(self, mocker) -> None:
-        """Test that running the ."""
-        test_input = (
-            "Test Title\nTest Description\n0.5.0\nhttps://myrepo.com\nMIT\ntest_user\n"
-            "test_user@test.com\nhttps://mysite.com\n\n"
-        )
-        mocker.patch.object(sys, "stdin", io.StringIO(test_input))
+        """Test the 'get_data' function to read from user."""
+        mocker.patch.object(sys, "stdin", io.StringIO(self.test_input))
 
         input_values = get_data()
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,19 @@
+"""Test functions in the app.database module."""
+import pytest
+
+from app.database import db
+
+
+class TestDatabase:
+    """Class to test the database module."""
+
+    @pytest.mark.asyncio()
+    async def test_get_database(self) -> None:
+        """Test we get an async database session back."""
+        database = db.get_database()
+        assert database is not None
+        assert isinstance(database, db.AsyncGenerator)
+
+        session = await database.__anext__()
+        assert session is not None
+        assert isinstance(session, db.AsyncSession)


### PR DESCRIPTION
Merging early to fix test failures caused by misuse of `pyfakefs` library