### PR TITLE
Ensure user reads the release notes for the current breaking changes

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -75,6 +75,10 @@ class Settings(BaseSettings):
     mail_use_credentials: bool = True
     mail_validate_certs: bool = True
 
+    # gatekeeper settings!
+    # this is to ensure that people read the damn instructions and changelogs
+    i_read_the_damn_docs: bool = False
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 """Main file for the FastAPI Template."""
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -14,6 +15,17 @@ from app.config.settings import get_settings
 from app.database.db import async_session
 from app.resources import config_error
 from app.resources.routes import api_router
+
+# gatekeeper to ensure the user has read the docs and noted the major changes
+# since the last version.
+if not get_settings().i_read_the_damn_docs:
+    print(
+        "\n[red]ERROR:    [bold]You didn't read the docs and change the "
+        "settings in the .env file!\n"
+        "\nThe API has changed massively since version 0.4.0 and you need to "
+        "familiarize yourself with the new breaking changes.\n"
+    )
+    sys.exit(666)
 
 
 @asynccontextmanager


### PR DESCRIPTION
Add a gatekeeper function to forbid running the server until the user has read the instructions and set an environment variable.

This will be removed in a few versions once the new structure and logic is proven