### PR TITLE
Allow setting a custom API root path e.g. "/api/v1" to prepend to all routes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 ## General
 
-- Allow a custom prefix to be added to all routes. For example `/api/v1` to
-  allow for API versioning.
 - Add an option to deactivate the root route `/` so it can be handled by a
   frontend instead. This also removes the index boilerplate.
 - add time-limited bans (configurable)

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -3,6 +3,7 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
+from pydantic import validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.config.helpers import get_project_root
@@ -32,6 +33,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=env_file)
 
     base_url: str = "http://localhost:8000"
+    api_root: str = ""
 
     cors_origins: str = "*"
 
@@ -78,6 +80,13 @@ class Settings(BaseSettings):
     # gatekeeper settings!
     # this is to ensure that people read the damn instructions and changelogs
     i_read_the_damn_docs: bool = False
+
+    @validator("api_root", pre=True)
+    def check_api_root(cls, value: str) -> str:
+        """Ensure the api_root does not end with a slash."""
+        if value and value.endswith("/"):
+            return value[:-1]
+        return value
 
 
 @lru_cache

--- a/app/resources/routes.py
+++ b/app/resources/routes.py
@@ -1,9 +1,10 @@
 """Include all the other routes into one router."""
 from fastapi import APIRouter
 
+from app.config.settings import get_settings
 from app.resources import auth, home, user
 
-api_router = APIRouter()
+api_router = APIRouter(prefix=get_settings().api_root)
 
 api_router.include_router(user.router)
 api_router.include_router(auth.router)

--- a/docs/usage/configuration/environment.md
+++ b/docs/usage/configuration/environment.md
@@ -21,6 +21,19 @@ system. Knowing this allows the API to build paths in responses and internally.
 BASE_URL=https://api.my-server.com
 ```
 
+## Set the API Root Prefix (Optional)
+
+If you want to add a prefix to all the routes, you can set it here. This is
+useful if you are running multiple APIs on the same server and want to avoid
+route conflicts, or for versioning.
+
+```ini
+API_ROOT=/api-v1
+```
+
+This will prefix all routes with `/api-v1`, so `/users` becomes `/api-v1/users`
+and so on. If this is not set, the API will use the root `/` as the prefix.
+
 ## Configure the database Settings
 
 Edit the below part of the `.env` file to configure your database. If this is

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,29 @@
+"""Test the Settings module validation functions."""
+from app.config.settings import Settings
+
+
+class TestValidateSettings:
+    """Test the Settings module validation functions."""
+
+    test_root = "/api/v1"
+
+    def test_api_root_ends_with_slash(self) -> None:
+        """A trailing slash should be removed from the api_root."""
+        settings = Settings(api_root=f"{self.test_root}/")
+        assert (
+            settings.api_root == self.test_root
+        ), "api_root should have trailing slash removed"
+
+    def test_api_root_without_trailing_slash(self) -> None:
+        """Good api_root should remain unchanged."""
+        settings = Settings(api_root=self.test_root)
+        assert (
+            settings.api_root == self.test_root
+        ), "api_root should remain unchanged"
+
+    def test_api_root_empty_string(self) -> None:
+        """Empty string should be handled correctly."""
+        settings = Settings(api_root="")
+        assert (
+            settings.api_root == ""
+        ), "api_root should handle empty strings correctly"


### PR DESCRIPTION
set the `API_ROOT` variable in the `.env`file to enable this. If unset then it will be ignored