### PR TITLE
Update the coverage action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       SKIP_COVERAGE_UPLOAD: true
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SKIP_COVERAGE_UPLOAD: false
+      SKIP_COVERAGE_UPLOAD: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,13 +71,6 @@ jobs:
       - name: Test with pytest
         run: |
           poetry run pytest --cov-report=xml
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-python-${{ matrix.python-version }}
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@v1
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SKIP_COVERAGE_UPLOAD: false
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +74,7 @@ jobs:
         run: |
           poetry run pytest --cov-report=xml
       - name: Run codacy-coverage-reporter
+        if: env.SKIP_COVERAGE_UPLOAD != 'true'
         uses: codacy/codacy-coverage-reporter-action@v1
         continue-on-error: true
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,7 @@ jobs:
           name: codecov-python-${{ matrix.python-version }}
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@v1
+        continue-on-error: true
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SKIP_COVERAGE_UPLOAD: true
+      SKIP_COVERAGE_UPLOAD: false
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
@@ -74,7 +74,7 @@ jobs:
         run: |
           poetry run pytest --cov-report=xml
       - name: Run codacy-coverage-reporter
-        if: ${{ env.SKIP_COVERAGE_UPLOAD != 'true' }}
+        if: ${{ env.SKIP_COVERAGE_UPLOAD != 'true'}}
         uses: codacy/codacy-coverage-reporter-action@v1
         continue-on-error: true
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           poetry run pytest --cov-report=xml
       - name: Run codacy-coverage-reporter
-        if: env.SKIP_COVERAGE_UPLOAD != 'true'
+        if: ${{ env.SKIP_COVERAGE_UPLOAD != 'true' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         continue-on-error: true
         with:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ good [Basic](https://fastapi.tiangolo.com/tutorial/) and
 [Advanced](https://fastapi.tiangolo.com/advanced/) User Guides on the FastAPI
 website .
 
-Visit our [Documentation Pages][doc] for usage, how-to's and more.
+Visit the [Installation Instructions][install] for more detailed installation
+notes, including how to handle the coverage uploader.
 
 ## Docker
 
@@ -289,3 +290,4 @@ this template, please feel free to start a discussion.
 [doc]:https://api-template.seapagan.net
 [contrib]:https://api-template.seapagan.net/contributing/
 [breaking]:https://api-template.seapagan.net/important/
+[install]:https://api-template.seapagan.net/usage/installation/

--- a/docs/important.md
+++ b/docs/important.md
@@ -1,4 +1,20 @@
-# Breaking Changes from 0.4.x
+# Breaking Changes
+
+This page contains information about breaking changes in the API. It is
+important to read this page if you are upgrading from a previous version of the
+API.
+
+## Breaking Changes in  0.5.1
+
+There is a minor potentially breaking change in this release.
+
+### Docker Port Change
+
+Under docker only, the API will now run on port `8001` instead of `8000`. This
+is to avoid conflicts with a local server or other services that may be running
+on the host machine.
+
+## Breaking Changes from 0.4.x
 
 From version **0.5.0,** there have been some **major breaking changes to the
 API**.
@@ -18,7 +34,7 @@ API**.
     Be aware that this branch will not be maintained and will not receive any
     updates or bug fixes.
 
-## Migrated to Async SQLAlchemy 2.0 for database access
+### Migrated to Async SQLAlchemy 2.0 for database access
 
 Previously, we used
 [encode/databases](https://www.encode.io/databases/){:target="_blank"} for the
@@ -32,7 +48,7 @@ documentation][sqlalchemy-async-orm]{:target="_blank"} for more information
 
 [sqlalchemy-async-orm]:https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#synopsis-orm
 
-## The CLI is an installable package
+### The CLI is an installable package
 
 This means that the `api-admin` command is now a package and installed in your
 local virtual environment when you run `poetry install`. With this you can run
@@ -48,14 +64,14 @@ api-admin --help
     run the `api-admin` command as a Python module. For example, `python -m
     api-admin`.
 
-## Full Test coverage
+### Full Test coverage
 
 The API now has full test coverage (using
 [Pytest](https://pytest.org){:target="_blank"}). This means that testing will be
 enforced on all PR's and that the test suite will be run by GitHub Actions on
 every commit and PR. This is to ensure that the API is stable and reliable.
 
-## Linting Changes
+### Linting Changes
 
 The project has moved completely over to using
 [Ruff](https://docs.astral.sh/ruff/){:target="_blank"} for Linting
@@ -66,17 +82,19 @@ tool. I have set the rules quite strict also! All exisiting code passes these
 checks, or is whitelisted for a very good reason. This will be enforced for all
 PR's also. All tools are configured in the `pyproject.toml` file.
 
-## Type Hints
+### Type Hints
 
 All code now has full type hinting. This means that you can use the `mypy`
 tool to check for type errors in the code. This will be enforced for all PR's.
 
-## Dependency Updates
+### Dependency Updates
 
 All dependencies used are updated to the latest versions as of the `0.5.0`
 release and will be kept up to date using the GitHub Dependabot tool.
 
 ---
+
+## Update the `.env` file
 
 !!! danger "Did you Read all this?"
 

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,4 +1,4 @@
-# How to install this project
+# How to Use this project
 
 !!! info "Contribute!"
     If you make changes to the existing code, why not create a
@@ -6,7 +6,9 @@
 
     See [Contributing](../contributing.md) for more info.
 
-## As a GitHub template
+## Installation
+
+### As a GitHub template
 
 Click the 'Use this template' button at the top of the Repository on GitHub.
 This will create a new repository in your personal GitHub account (Not a Fork)
@@ -19,19 +21,78 @@ there are very good
 [Advanced](https://fastapi.tiangolo.com/advanced/){:target="_blank"} User Guides
 on the FastAPI website .
 
-## As a Fork
+### As a Fork
 
 You can also fork this project as usual, which allows you to easily bring it up
 to date with changes and improvements as they happen. This does have the
 posibility of conflicts. As long as you stick to adding new models and routes
 but not modifying the existing base code it should be ok.
 
-## Upgrading from a Patch file
+### Upgrading from a Patch file
 
-Sometime in the next few releases I will include patch files with the release to
-upgrade from the previous release. These can be applied by Git and will upgrade
-the Template code to the latest. The same warning applies as above - your
-changes can cause merge conflicts.
+In the
+[CHANGELOG.md](https://github.com/seapagan/fastapi-template/blob/main/CHANGELOG.md){:target="_blank"}
+file, there are links to `Patch` and `Diff` files to enable you to upgrade from
+a previous release. These can be applied by Git and will upgrade the Template
+code to that release. The same warning applies as above - your changes can cause
+merge conflicts.
 
 If you were a few releases behind, you can apply the patches in ascending
-version order to get to the latest.
+version order to get to the latest release.
+
+See [git apply](https://git-scm.com/docs/git-apply){:target="_blank"} and [git
+am](https://git-scm.com/docs/git-am){:target="_blank"} for more information on
+how to apply these.
+
+## Set GitHub Actions Secrets
+
+The only secret you need to set for the GitHub Actions is for
+[Codacy](https://www.codacy.com/){:target="_blank"} which is used for automatic
+code quality checks and test coverage reports.
+
+### Codacy API Token
+
+To use this, you will need to set up a (free) acccount with
+[Codacy](https://www.codacy.com/signup-codacy) to get your project token. You
+will then need to set the following secrets in your GitHub repository settings
+(`Settings -> Secrets and variables`):
+
+- `CODACY_PROJECT_TOKEN` - Your Codacy Project Token.
+
+!!! tip
+
+    See the next section if you don't want to use Codacy for test coverage.
+
+Note that this is the specific repository secrets, not in your profile settings.
+See the [Codacy
+Docs](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens){:target="_blank"}
+for more information and how to get your repository token.
+
+!!! danger "Important"
+
+    You will need to set the `CODACY_PROJECT_TOKEN` secret in your GitHub
+    repository settings both for `Actions` **AND** `Dependabot`. Set the same
+    variable and value in both places.
+
+    If you do not set this, the Codacy checks will fail and Dependabot will not
+    be able to merge Pull Requests.
+
+## Disable Test Coverage Reports (Optional)
+
+If you do not want to use Codacy for test coverage reports, you can disable the
+uploading of the reports by changing a variable in the
+`.github/workflows/tests.yml` file.
+
+Change the `SKIP_COVERAGE_UPLOAD` variable to `true` in the `env` section of the
+`tests` job. For example:
+
+```yaml hl_lines="5"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_COVERAGE_UPLOAD: true
+    strategy:
+```
+
+To revert this, change it back to `false`.


### PR DESCRIPTION
- [x] ensure that the CI run does not fail just because the coverage upload fails
- [x] remove `codecov` for coverage analysis, we will only use `codacy`.
- [x] allow skipping coverage upload by setting a variable in the action file
- [x] update docs to mention setting codacy environment variables on generated templates.