### PR TITLE
Add a Redis server to the docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.6-slim-bookworm AS dev
+FROM python:3.11.8-slim-bookworm AS dev
 RUN apt-get update -y && apt-get install -y \
     gcc \
     libpq-dev \


### PR DESCRIPTION
The `Redis` server will be used in the future for caching and rate-limiting at a minimum.

This PR simply adds a `redis` server to the existing Docker Compose setup.