### PR TITLE
Use the python logger in the API instead of print statements

### DIFF
--- a/app/config/helpers.py
+++ b/app/config/helpers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import rtoml
 
+from app.logs import logger
+
 
 def get_project_root() -> Path:
     """Return the full path of the project root."""
@@ -29,12 +31,12 @@ def get_api_version() -> str:
         config = rtoml.load(get_toml_path())
         version: str = config["project"]["version"]
 
-    except KeyError as exc:
-        print(f"Cannot find the API version in the pyproject.toml file : {exc}")
+    except KeyError:
+        logger.error("Cannot find the API version in the pyproject.toml file")
         sys.exit(2)
 
     except OSError as exc:
-        print(f"Cannot read the pyproject.toml file : {exc}")
+        logger.error(f"Cannot read the pyproject.toml file : {exc}")
         sys.exit(2)
 
     else:
@@ -52,15 +54,14 @@ def get_api_details() -> tuple[str, str, list[dict[str, str]]]:
         if not isinstance(authors, list):
             authors = [authors]
 
-    except KeyError as exc:
-        print(
-            "Missing name/description or authors in the pyproject.toml file "
-            f": {exc}"
+    except KeyError:
+        logger.error(
+            "Missing name/description or authors in the pyproject.toml file"
         )
         sys.exit(2)
 
     except OSError as exc:
-        print(f"Cannot read the pyproject.toml file : {exc}")
+        logger.error(f"Cannot read the pyproject.toml file : {exc}")
         sys.exit(2)
     else:
         return (name, desc, authors)

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -10,14 +10,15 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.config.helpers import get_project_root
+from app.logs import logger
 
 try:
     from .metadata import custom_metadata
 except ModuleNotFoundError:  # pragma: no cover
-    print(
-        "The metadata file could not be found, it may have been deleted.\n"
-        "Please run 'api-admin custom init' to regenerate defaults."
+    logger.error(
+        "The metadata file could not be found, it may have been deleted."
     )
+    logger.error("Please run 'api-admin custom init' to regenerate defaults.")
     sys.exit(1)
 
 

--- a/app/logs.py
+++ b/app/logs.py
@@ -1,0 +1,5 @@
+"""Get the 'uvicorn' logger so we can use it in our own logger."""
+
+import logging
+
+logger = logging.getLogger("uvicorn")

--- a/tests/cli/test_gatekeeper.py
+++ b/tests/cli/test_gatekeeper.py
@@ -29,4 +29,4 @@ class TestCLI:
         )
 
         assert result.returncode == BLIND_USER_ERROR
-        assert "You didn't read the docs" in result.stdout
+        assert "You didn't read the docs" in result.stderr


### PR DESCRIPTION
Remove all print statements from the API and replace with the relevant logger usage. The CLI still uses `print` for now.