### PR TITLE
fix deprecation warning in tests due to httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "rtoml>=0.11.0",
   "jinja2>=3.1.4",
   "fastapi-mail>=1.4.1",
-  "httpx==0.27.2",
+  "httpx>=0.27.2",
   "uvicorn[standard]>=0.32.0",
   "passlib[bcrypt]>=1.7.4",
   "sqlalchemy[asyncio]>=2.0.36",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,7 +48,7 @@ h11==0.14.0
 htmlmin2==0.1.13
 httpcore==1.0.7
 httptools==0.6.4
-httpx==0.27.2
+httpx==0.28.1
 identify==2.6.6
 idna==3.10
 importlib-metadata==8.6.1 ; python_full_version < '3.10'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ greenlet==3.1.1
 h11==0.14.0
 httpcore==1.0.7
 httptools==0.6.4
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jinja2==3.1.5
 mako==1.3.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -93,8 +93,11 @@ async def test_db() -> AsyncGenerator[AsyncSession, Any]:
 async def client() -> AsyncGenerator[AsyncClient, Any]:
     """Fixture to yield a test client for the app."""
     app.dependency_overrides[get_database] = get_database_override
+
+    transport = ASGITransport(app=app)
+
     async with AsyncClient(
-        app=app,
+        transport=transport,
         base_url="http://testserver",
         headers={"Content-Type": "application/json"},
         timeout=10,

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4" },
     { name = "fastapi-mail", specifier = ">=1.4.1" },
-    { name = "httpx", specifier = "==0.27.2" },
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "psycopg2", specifier = ">=2.9.10" },
@@ -1026,18 +1026,17 @@ wheels = [
 
 [[package]]
 name = "httpx"
-version = "0.27.2"
+version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
-    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/82/08f8c936781f67d9e6b9eeb8a0c8b4e406136ea4c3d1f89a5db71d42e0e6/httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2", size = 144189 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0", size = 76395 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]


### PR DESCRIPTION
the `httpx`library (used for the test runner) has deprecated the old way the app is passed, which raises a deprecation warning in the tests. We had originally pinned an older version until `Starlette` changed it's code, that is released now too.