### PR TITLE
use latest versions of postgresql and python in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS dev
+FROM python:3.13-slim AS dev
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt-get update -y && apt-get install -y \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 - 2023 Grant Ramsay
+Copyright (c) 2022 - 2025 Grant Ramsay
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/config/metadata.py
+++ b/app/config/metadata.py
@@ -20,5 +20,5 @@ custom_metadata = MetadataBase(
         "url": "https://www.gnramsay.com",
     },
     email="seapagan@gmail.com",
-    year="2024",
+    year="2022-2025",
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         condition: service_healthy
 
   db:
-    image: postgres:15.6-bullseye
+    image: postgres:17.3-bullseye
     hostname: postgres
     environment:
       POSTGRES_USER: ${DB_USER}

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,5 +1,25 @@
 # Run a server using Docker
 
+## PostgreSQL versions
+
+At times we will update the Docker configurations to use a newer version of
+PostgreSQL. Often, the newer version will be incompatible with the existing
+database, and you will need to create a new database.
+
+For example between releases `0.5.4` and `0.6.0` I updated the docker config to
+use PostgreSQL **17** instead of **15**. In this case the existing database was
+not compatible.
+
+You have 3 options in this case:
+
+1. delete the docker volume `api-db-data` and just start again. This is fine if
+   you are only using docker for testing.
+2. change the `docker-compose.yml` to use the previous version of PostgreSQL
+   instead. In the case of `0.6.0` you can change back to `15.6-bullseye`. This
+   is on line **25** (as of version `0.6.0` anyway).
+3. log into the docker instance and migrate the data to version 17. There are
+   several guides for this if you search.
+
 ## Run a Server
 
 Docker containers can be used for testing the API during development just make

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,9 @@ lint.help = "Run all linting checks"
 "docs:publish".help = "Publish documentation to GitHub Pages"
 "docs:build".cmd = "mkdocs build"
 "docs:build".help = "Build documentation locally to './site' folder"
-"docs:serve".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -w BUGS.md"
+"docs:serve".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md"
 "docs:serve".help = "Serve documentation locally"
-"docs:serve:all".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -w BUGS.md -a 0.0.0.0:8000"
+"docs:serve:all".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -a 0.0.0.0:8000"
 "docs:serve:all".help = "Serve documentation locally on all interfaces"
 
 # regenerate the openapi.json file


### PR DESCRIPTION
Use Python version `3.13` and PostgreSQL version `17.3` in the docker configs. 

This is a potential breaking change if you have an existing docker database, since any existing data is not compatible with postgres 17. You have 3 options:

1) delete the docker volume `api-db-data` and just start again. This is fine if you are only using docker for testing.
2) change the `docker-compose.yml` to use the previous version of `15.6-bullseye` instead. This is on line **25** (as of this PR anyway)
3) log into the docker instance and migrate the data to version 17. There are several guides for this if you search.