### PR TITLE
Allow Admin users to list/edit/delete other users API keys

### DIFF
--- a/app/managers/api_key.py
+++ b/app/managers/api_key.py
@@ -20,8 +20,8 @@ from app.models.api_key import ApiKey
 from app.models.user import User
 
 
-class ResponseMessages:
-    """Error strings for different circumstances."""
+class ApiKeyErrorMessages:
+    """Error strings for API Key failures."""
 
     INVALID_KEY = "Invalid API key"
     KEY_INACTIVE = "API key is inactive"
@@ -139,7 +139,7 @@ class ApiKeyAuth:
             if self.auto_error:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=ResponseMessages.INVALID_KEY,
+                    detail=ApiKeyErrorMessages.INVALID_KEY,
                 )
             return None
 
@@ -148,7 +148,7 @@ class ApiKeyAuth:
             if self.auto_error:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=ResponseMessages.KEY_INACTIVE,
+                    detail=ApiKeyErrorMessages.KEY_INACTIVE,
                 )
             return None
 
@@ -158,7 +158,7 @@ class ApiKeyAuth:
             if self.auto_error:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail=ResponseMessages.INVALID_KEY,
+                    detail=ApiKeyErrorMessages.INVALID_KEY,
                 )
             return None
 

--- a/app/resources/api_key.py
+++ b/app/resources/api_key.py
@@ -14,7 +14,7 @@ from app.models.user import User
 from app.schemas.request.api_key import ApiKeyCreate, ApiKeyUpdate
 from app.schemas.response.api_key import ApiKeyCreateResponse, ApiKeyResponse
 
-router = APIRouter(tags=["API Keys"], prefix="/api/keys")
+router = APIRouter(tags=["API Keys"], prefix="/keys")
 
 
 @router.post("")

--- a/app/resources/api_key.py
+++ b/app/resources/api_key.py
@@ -8,12 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.db import get_database
 from app.database.helpers import update_api_key_
-from app.managers.api_key import ApiKeyManager
+from app.managers.api_key import ApiKeyErrorMessages, ApiKeyManager
 from app.managers.security import get_current_user
 from app.models.user import User
 from app.schemas.request.api_key import ApiKeyCreate, ApiKeyUpdate
 from app.schemas.response.api_key import ApiKeyCreateResponse, ApiKeyResponse
 
+# the prefix will later become configurable in the settings
 router = APIRouter(tags=["API Keys"], prefix="/keys")
 
 
@@ -77,7 +78,7 @@ async def update_api_key(
     if not key or key.user_id != user.id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="API key not found",
+            detail=ApiKeyErrorMessages.KEY_NOT_FOUND,
         )
 
     # Build update data
@@ -99,7 +100,7 @@ async def update_api_key(
     if not updated_key:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="API key not found",
+            detail=ApiKeyErrorMessages.KEY_NOT_FOUND,
         )
     return ApiKeyResponse.model_validate(updated_key.__dict__)
 
@@ -115,6 +116,6 @@ async def delete_api_key(
     if not key or key.user_id != user.id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="API key not found",
+            detail=ApiKeyErrorMessages.KEY_NOT_FOUND,
         )
     await ApiKeyManager.delete_key(key_id, db)

--- a/app/resources/api_key.py
+++ b/app/resources/api_key.py
@@ -15,7 +15,7 @@ from app.schemas.request.api_key import ApiKeyCreate, ApiKeyUpdate
 from app.schemas.response.api_key import ApiKeyCreateResponse, ApiKeyResponse
 
 # the prefix will later become configurable in the settings
-router = APIRouter(tags=["API Keys"], prefix="/keys")
+router = APIRouter(tags=["API Keys"], prefix="/users/keys")
 
 
 @router.post("")

--- a/docs/usage/api-keys.md
+++ b/docs/usage/api-keys.md
@@ -45,11 +45,11 @@ Now, you can access this route using an **API Key** OR a **JWT** token.
 
 There are 5 routes for managing API Keys and are **USER Specific**:
 
-1. **List All API Keys** - `GET /api/keys/`
-2. **Create a new API Key** - `POST /api/keys/`
-3. **Get a single API Key** - `GET /api/keys/{key_id}`
-4. **Update a single API Key** - `PATCH /api/keys/{key_id}`
-5. **Delete a single API Key** - `DELETE /api/keys/{key_id}`
+1. **List All API Keys** - `GET /users/keys/`
+2. **Create a new API Key** - `POST /users/keys/`
+3. **Get a single API Key** - `GET /users/keys/{key_id}`
+4. **Update a single API Key** - `PATCH /users/keys/{key_id}`
+5. **Delete a single API Key** - `DELETE /users/keys/{key_id}`
 
 !!! danger
     The `POST` route will return the API Key in the response. **This is

--- a/docs/usage/api-keys.md
+++ b/docs/usage/api-keys.md
@@ -51,6 +51,12 @@ There are 5 routes for managing API Keys and are **USER Specific**:
 4. **Update a single API Key** - `PATCH /users/keys/{key_id}`
 5. **Delete a single API Key** - `DELETE /users/keys/{key_id}`
 
+There are also 3 related routes that can only be accessed by an admin user:
+
+1. **List API Keys for a specific user** - `GET /users/keys/by-user/{user_id}`
+2. **Update another user's API key** - `PATCH /users/keys/by-user/{user_id}/{key_id}`
+3. **Delete another user's API key** - `DELETE /users/keys/by-user/{user_id}/{key_id}`
+
 !!! danger
     The `POST` route will return the API Key in the response. **This is
     the only time the key is shown**. If you lose it, you will have to delete

--- a/tests/integration/test_api_key_routes.py
+++ b/tests/integration/test_api_key_routes.py
@@ -435,7 +435,7 @@ class TestApiKeyRoutes:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert len(data) == 2
+        assert len(data) == 2  # noqa: PLR2004
         assert all(isinstance(UUID(key["id"]), UUID) for key in data)
         assert "key" not in data[0]
         assert "key" not in data[1]

--- a/tests/integration/test_api_key_routes.py
+++ b/tests/integration/test_api_key_routes.py
@@ -15,7 +15,7 @@ from app.models.user import User
 
 # this should become a config setting later, so we can change the route and
 # tests in one place.
-API_KEY_ROUTE = "/keys"
+API_KEY_ROUTE = "/users/keys"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_api_key_routes.py
+++ b/tests/integration/test_api_key_routes.py
@@ -13,6 +13,10 @@ from app.managers.user import pwd_context
 from app.models.enums import RoleType
 from app.models.user import User
 
+# this should become a config setting later, so we can change the route and
+# tests in one place.
+API_KEY_ROUTE = "/keys"
+
 
 @pytest.mark.integration
 class TestApiKeyRoutes:
@@ -46,7 +50,7 @@ class TestApiKeyRoutes:
 
         # Create API key
         response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users", "write:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -73,19 +77,19 @@ class TestApiKeyRoutes:
 
         # Create an API key first
         await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key 1", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
         await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key 2", "scopes": ["write:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
 
         # List API keys
         response = await client.get(
-            "/api/keys",
+            API_KEY_ROUTE,
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -109,7 +113,7 @@ class TestApiKeyRoutes:
 
         # Create an API key
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -117,7 +121,7 @@ class TestApiKeyRoutes:
 
         # Get the specific key
         response = await client.get(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -140,7 +144,7 @@ class TestApiKeyRoutes:
 
         # Create an API key
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -148,7 +152,7 @@ class TestApiKeyRoutes:
 
         # Update the key
         response = await client.patch(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             json={"name": "Updated Key", "is_active": False},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -171,7 +175,7 @@ class TestApiKeyRoutes:
 
         # Create an API key
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -179,7 +183,7 @@ class TestApiKeyRoutes:
 
         # Delete the key
         response = await client.delete(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -187,7 +191,7 @@ class TestApiKeyRoutes:
 
         # Verify key is deleted
         get_response = await client.get(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert get_response.status_code == status.HTTP_404_NOT_FOUND
@@ -210,7 +214,7 @@ class TestApiKeyRoutes:
 
         # Create an API key for user1
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "User1 Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token1}"},
         )
@@ -218,7 +222,7 @@ class TestApiKeyRoutes:
 
         # Try to access user1's key with user2's token
         response = await client.get(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             headers={"Authorization": f"Bearer {token2}"},
         )
 
@@ -230,7 +234,7 @@ class TestApiKeyRoutes:
     ) -> None:
         """Test creating an API key without authentication."""
         response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
         )
 
@@ -249,7 +253,7 @@ class TestApiKeyRoutes:
 
         # Try to update a non-existent key
         response = await client.patch(
-            "/api/keys/00000000-0000-0000-0000-000000000000",
+            f"{API_KEY_ROUTE}/00000000-0000-0000-0000-000000000000",
             json={"name": "Updated Key", "is_active": False},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -270,7 +274,7 @@ class TestApiKeyRoutes:
 
         # Try to delete a non-existent key
         response = await client.delete(
-            "/api/keys/00000000-0000-0000-0000-000000000000",
+            f"{API_KEY_ROUTE}/00000000-0000-0000-0000-000000000000",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -290,7 +294,7 @@ class TestApiKeyRoutes:
 
         # Test with missing required field
         response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"scopes": ["read:users"]},  # Missing 'name' field
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -298,7 +302,7 @@ class TestApiKeyRoutes:
 
         # Test with invalid scopes format
         response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={
                 "name": "Test Key",
                 "scopes": "invalid",
@@ -320,7 +324,7 @@ class TestApiKeyRoutes:
 
         # Create an API key first
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -328,7 +332,7 @@ class TestApiKeyRoutes:
 
         # Test with invalid is_active type
         response = await client.patch(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             json={
                 "name": "Updated Key",
                 "is_active": "invalid",
@@ -339,7 +343,7 @@ class TestApiKeyRoutes:
 
         # Test with invalid name length
         response = await client.patch(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             json={"name": ""},  # Empty name is not allowed
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -347,7 +351,7 @@ class TestApiKeyRoutes:
 
         # Test with empty update data
         response = await client.patch(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             json={},  # Empty update data
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -370,7 +374,7 @@ class TestApiKeyRoutes:
 
         # Create an API key
         create_response = await client.post(
-            "/api/keys",
+            API_KEY_ROUTE,
             json={"name": "Test Key", "scopes": ["read:users"]},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -381,7 +385,7 @@ class TestApiKeyRoutes:
 
         # Try to update the key
         response = await client.patch(
-            f"/api/keys/{key_id}",
+            f"{API_KEY_ROUTE}/{key_id}",
             json={"name": "Updated Key"},
             headers={"Authorization": f"Bearer {token}"},
         )

--- a/tests/unit/test_api_key_auth.py
+++ b/tests/unit/test_api_key_auth.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import HTTPException, status
 
 from app.database.helpers import update_api_key_
-from app.managers.api_key import ApiKeyAuth, ApiKeyManager, ResponseMessages
+from app.managers.api_key import ApiKeyAuth, ApiKeyErrorMessages, ApiKeyManager
 from app.managers.user import UserManager
 from app.models.user import User
 
@@ -30,7 +30,7 @@ class TestApiKeyAuth:
         user = await UserManager.get_user_by_email(
             self.test_user["email"], test_db
         )
-        api_key, raw_key = await ApiKeyManager.create_key(
+        _, raw_key = await ApiKeyManager.create_key(
             user, "Test Key", None, test_db
         )
 
@@ -55,7 +55,7 @@ class TestApiKeyAuth:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.INVALID_KEY
+        assert exc.value.detail == ApiKeyErrorMessages.INVALID_KEY
 
     async def test_api_key_auth_no_header(self, test_db, mocker) -> None:
         """Test with no API key header."""
@@ -91,4 +91,4 @@ class TestApiKeyAuth:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.KEY_INACTIVE
+        assert exc.value.detail == ApiKeyErrorMessages.KEY_INACTIVE

--- a/tests/unit/test_api_key_manager.py
+++ b/tests/unit/test_api_key_manager.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import HTTPException, status
 from sqlalchemy import delete
 
-from app.managers.api_key import ApiKeyAuth, ApiKeyManager, ResponseMessages
+from app.managers.api_key import ApiKeyAuth, ApiKeyErrorMessages, ApiKeyManager
 from app.managers.user import UserManager
 from app.models.api_key import ApiKey
 from app.models.user import User
@@ -120,7 +120,7 @@ class TestApiKeyManager:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.INVALID_KEY
+        assert exc.value.detail == ApiKeyErrorMessages.INVALID_KEY
 
     async def test_api_key_auth_inactive_key_no_auto_error(
         self, test_db, mocker
@@ -171,7 +171,7 @@ class TestApiKeyManager:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.KEY_INACTIVE
+        assert exc.value.detail == ApiKeyErrorMessages.KEY_INACTIVE
 
     async def test_api_key_auth_user_not_found(self, test_db, mocker) -> None:
         """Test API key auth when user is not found."""
@@ -199,7 +199,7 @@ class TestApiKeyManager:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.INVALID_KEY
+        assert exc.value.detail == ApiKeyErrorMessages.INVALID_KEY
 
     async def test_api_key_auth_user_not_found_no_auto_error(
         self, test_db, mocker
@@ -293,7 +293,7 @@ class TestApiKeyManager:
             await auth(request=mock_req, db=test_db)
 
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == ResponseMessages.INVALID_KEY
+        assert exc.value.detail == ApiKeyErrorMessages.INVALID_KEY
 
     async def test_api_key_auth_user_not_found_in_db_no_auto_error(
         self, test_db, mocker


### PR DESCRIPTION
Add 3 more routes that allow an admin to list/edit and delete the API keys for a specific user.