### PR TITLE
add user search endpoint with pagination and CLI command for same

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ updates or bug fixes.
 This template is a ready-to-use boilerplate for a FastAPI project. It has the
 following advantages to starting your own from scratch :
 
-- Baked-in User database and management. Routes are provided to add/edit/delete
-  or ban (and unban) Users.
+- Baked-in User database and management. Routes are provided to
+  add/edit/delete/search or ban (and unban) Users.
 - Postgresql Integration, using SQLAlchemy ORM, no need for raw SQL queries
   (unless you want to!). All database usage is Asynchronous.
   [Alembic][alembic] is used to control database

--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -379,18 +379,18 @@ def search(
 ) -> None:
     """Search for users by email, first name, or last name."""
 
+    # Convert string field to enum and get display name
+    field_enum = getattr(SearchField, field.upper(), SearchField.ALL)
+    field_display = (
+        "all fields"
+        if field_enum == SearchField.ALL
+        else field_enum.name.lower()
+    )
+
     async def _search_users() -> list[User]:
         """Async function to search for users."""
         try:
             async with async_session() as session:
-                # Convert string field to enum
-                try:
-                    field_enum = getattr(
-                        SearchField, field.upper(), SearchField.ALL
-                    )
-                except (KeyError, AttributeError):
-                    field_enum = SearchField.ALL
-
                 query = await UserManager.search_users(
                     search_term, field_enum, exact_match=exact
                 )
@@ -402,13 +402,10 @@ def search(
 
     users = aiorun(_search_users())
     if users:
-        field_display = field if field != "all" else "all fields"
         match_type = "exact" if exact else "partial"
         show_table(
-            (
-                f"Users matching '{search_term}' in {field_display} "
-                f"({match_type} match)"
-            ),
+            f"Users matching '{search_term}' in {field_display} "
+            f"({match_type} match)",
             users,
         )
     else:

--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -378,7 +378,6 @@ def search(
     ),
 ) -> None:
     """Search for users by email, first name, or last name."""
-
     # Convert string field to enum and get display name
     field_enum = getattr(SearchField, field.upper(), SearchField.ALL)
     field_display = (

--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -16,9 +16,11 @@ from app.database.db import async_session
 from app.managers.user import UserManager
 from app.models.enums import RoleType
 from app.models.user import User
+from app.schemas.request.user import SearchField
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
+
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -351,3 +353,66 @@ def delete(
     else:
         rprint("\n[red]-> ERROR deleting that User : [bold]User not found\n")
         raise typer.Exit(1)
+
+
+@app.command()
+def search(
+    search_term: str = typer.Argument(
+        ...,
+        help="Search term to find users",
+        show_default=False,
+    ),
+    field: str = typer.Option(
+        "all",
+        "--field",
+        "-f",
+        help="Field to search in (all, email, first_name, last_name)",
+    ),
+    *,
+    exact: bool = typer.Option(
+        False,
+        "--exact",
+        "-e",
+        help="Use exact matching instead of partial matching",
+        is_flag=True,
+    ),
+) -> None:
+    """Search for users by email, first name, or last name."""
+
+    async def _search_users() -> list[User]:
+        """Async function to search for users."""
+        try:
+            async with async_session() as session:
+                # Convert string field to enum
+                try:
+                    field_enum = getattr(
+                        SearchField, field.upper(), SearchField.ALL
+                    )
+                except (KeyError, AttributeError):
+                    field_enum = SearchField.ALL
+
+                query = await UserManager.search_users(
+                    search_term, field_enum, exact_match=exact
+                )
+                result = await session.execute(query)
+                return list(result.scalars().all())
+        except SQLAlchemyError as exc:
+            rprint(f"\n[red]-> ERROR searching Users : [bold]{exc}\n")
+            raise typer.Exit(1) from exc
+
+    users = aiorun(_search_users())
+    if users:
+        field_display = field if field != "all" else "all fields"
+        match_type = "exact" if exact else "partial"
+        show_table(
+            (
+                f"Users matching '{search_term}' in {field_display} "
+                f"({match_type} match)"
+            ),
+            users,
+        )
+    else:
+        rprint(
+            "\n[yellow]-> No users found matching "
+            f"'[bold]{search_term}[/bold]'\n"
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi_pagination import add_pagination
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.admin import register_admin
@@ -94,3 +95,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add pagination support
+add_pagination(app)

--- a/app/managers/user.py
+++ b/app/managers/user.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from email_validator import EmailNotValidError, validate_email
 from fastapi import BackgroundTasks, HTTPException, status
-from sqlalchemy import delete, or_, select, update
+from sqlalchemy import Select, delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.config.settings import get_settings
@@ -26,6 +26,7 @@ from app.schemas.request.user import SearchField
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
+    from typing import Any
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -324,7 +325,7 @@ class UserManager:
         field: SearchField,
         *,
         exact_match: bool,
-    ) -> Any:  # Using Any to avoid mypy issues with SQLAlchemy types
+    ) -> Select[tuple[User]]:
         """Create a search query for users.
 
         Returns the query for pagination to handle.

--- a/app/managers/user.py
+++ b/app/managers/user.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from email_validator import EmailNotValidError, validate_email
 from fastapi import BackgroundTasks, HTTPException, status
-from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy import delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.config.settings import get_settings
@@ -28,7 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
 
     from sqlalchemy.ext.asyncio import AsyncSession
-    from sqlalchemy.sql import Select
 
     from app.models.enums import RoleType
     from app.schemas.request.user import (
@@ -325,10 +324,9 @@ class UserManager:
         field: SearchField,
         *,
         exact_match: bool,
-        session: AsyncSession,
     ) -> Any:  # Using Any to avoid mypy issues with SQLAlchemy types
-        """
-        Create a search query for users.
+        """Create a search query for users.
+
         Returns the query for pagination to handle.
         """
         query = select(User)

--- a/app/resources/user.py
+++ b/app/resources/user.py
@@ -179,7 +179,6 @@ async def search_users(
         search_term,
         field_enum,
         exact_match=exact_match,
-        session=db,
     )
     # Use cast to help mypy understand the return type
     return cast(Page[UserResponse], await paginate(db, query))

--- a/app/resources/user.py
+++ b/app/resources/user.py
@@ -1,9 +1,11 @@
 """Routes for User listing and control."""
 
 from collections.abc import Sequence
-from typing import Annotated, Optional, Union
+from typing import Annotated, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, Request, status
+from fastapi_pagination import Page
+from fastapi_pagination.ext.sqlalchemy import paginate
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.db import get_database
@@ -12,7 +14,11 @@ from app.managers.security import get_current_user
 from app.managers.user import UserManager
 from app.models.enums import RoleType
 from app.models.user import User
-from app.schemas.request.user import UserChangePasswordRequest, UserEditRequest
+from app.schemas.request.user import (
+    SearchField,
+    UserChangePasswordRequest,
+    UserEditRequest,
+)
 from app.schemas.response.user import MyUserResponse, UserResponse
 
 router = APIRouter(tags=["Users"], prefix="/users")
@@ -147,3 +153,33 @@ async def delete_user(
     Admin only.
     """
     await UserManager.delete_user(user_id, db)
+
+
+@router.get(
+    "/search",
+    dependencies=[Depends(get_current_user), Depends(is_admin)],
+    summary="Search users",
+    description="Search for users with various criteria. Admin only endpoint.",
+)
+async def search_users(
+    db: Annotated[AsyncSession, Depends(get_database)],
+    search_term: str,
+    field: str = "all",
+    *,
+    exact_match: bool = False,
+) -> Page[UserResponse]:
+    """Search for users with pagination and filtering."""
+    # Convert string field to enum
+    try:
+        field_enum = SearchField[field.upper()]
+    except (KeyError, AttributeError):
+        field_enum = SearchField.ALL
+
+    query = await UserManager.search_users(
+        search_term,
+        field_enum,
+        exact_match=exact_match,
+        session=db,
+    )
+    # Use cast to help mypy understand the return type
+    return cast(Page[UserResponse], await paginate(db, query))

--- a/app/schemas/request/user.py
+++ b/app/schemas/request/user.py
@@ -1,9 +1,34 @@
 """Define Schemas used by the User routes."""
 
+from enum import Enum
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.base import UserBase
 from app.schemas.examples import ExampleUser
+
+
+class SearchField(str, Enum):
+    """Enum for user search fields."""
+
+    ALL = "all"
+    EMAIL = "email"
+    FIRST_NAME = "first_name"
+    LAST_NAME = "last_name"
+
+
+class UserSearchParams(BaseModel):
+    """Parameters for searching users."""
+
+    search_term: str = Field(
+        ..., min_length=1, description="Term to search for"
+    )
+    field: SearchField = Field(
+        default=SearchField.ALL, description="Field to search in"
+    )
+    exact_match: bool = Field(
+        default=False, description="Whether to perform exact matching"
+    )
 
 
 class UserRegisterRequest(UserBase):

--- a/docs/project-organization.md
+++ b/docs/project-organization.md
@@ -17,6 +17,10 @@ suitable defaults. Non-secret (or depoloyment independent) settings should go
 in the `metadata` file, while secrets (or deployment specific) should go in the
 `settings` and `.env` files
 
+**admin/** - This directory contains the Admin interface setup. You can add more
+models here, or modify the existing ones. The Admin interface is used to manage
+the database content, and is available at the `/admin` route.
+
 **commands/** - This directory can hold any **CLI** commands you need to write,
 for example populating a database, create a superuser or other housekeeping
 tasks.

--- a/docs/usage/user-control.md
+++ b/docs/usage/user-control.md
@@ -55,7 +55,41 @@ $ api-admin user verify 23
 
 ## Search for a user
 
-- This functionality is *Currently not implemented*
+You can search for users using various criteria. The search command supports
+partial matching by default and can search across all fields or a specific
+field.
+
+Basic search (searches all fields):
+
+```console
+$ api-admin user search "john"
+```
+
+!!! tip
+    The quotes around the search term are optional if the term does not contain
+    spaces. For example, both `api-admin user search john` and `api-admin user
+    search "john"` are valid.
+
+Search in a specific field:
+
+```console
+$ api-admin user search "john" --field first_name
+```
+
+The available fields are:
+
+- `email`
+- `first_name`
+- `last_name`
+- `all` (default)
+
+For exact matching, use the `--exact` flag:
+
+```console
+$ api-admin user search "john.doe@example.com" --exact
+```
+
+The search results will be displayed in a table showing the user's Id, Email address, First and Last name, Role, and the Verified and Banned Status.
 
 ## Ban or Unban a specific User
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "libpass[bcrypt]>=1.9.0",
   "bcrypt>=4.0.1",
   "sqladmin[full]>=0.20.1",
+  "fastapi-pagination>=0.12.34",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,6 +37,7 @@ faker==36.1.1
 fastapi==0.115.8
 fastapi-cli==0.0.7
 fastapi-mail==1.4.2
+fastapi-pagination==0.12.34
 filelock==3.17.0
 ghp-import==2.1.0
 gitdb==4.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ exceptiongroup==1.2.2 ; python_full_version < '3.11'
 fastapi==0.115.8
 fastapi-cli==0.0.7
 fastapi-mail==1.4.2
+fastapi-pagination==0.12.34
 greenlet==3.1.1
 h11==0.14.0
 httpcore==1.0.7

--- a/tests/cli/test_cli_user_command.py
+++ b/tests/cli/test_cli_user_command.py
@@ -636,7 +636,8 @@ class TestCLI:
         # Mock the execute chain to return test_user
         mock_result = mocker.MagicMock()
         mock_result.scalars.return_value.all.return_value = [test_user]
-        mock_session.return_value.__aenter__.return_value.execute.return_value = mock_result
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.return_value = mock_result
         result = runner.invoke(app, ["user", "search", "test@example.com"])
         assert result.exit_code == 0
 
@@ -679,7 +680,8 @@ class TestCLI:
         # Mock the execute chain to return test_user
         mock_result = mocker.MagicMock()
         mock_result.scalars.return_value.all.return_value = [test_user]
-        mock_session.return_value.__aenter__.return_value.execute.return_value = mock_result
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.return_value = mock_result
         result = runner.invoke(
             app, ["user", "search", "john", "--field", "first_name"]
         )
@@ -714,7 +716,8 @@ class TestCLI:
         # Mock the execute chain to return test_user
         mock_result = mocker.MagicMock()
         mock_result.scalars.return_value.all.return_value = [test_user]
-        mock_session.return_value.__aenter__.return_value.execute.return_value = mock_result
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.return_value = mock_result
         result = runner.invoke(
             app, ["user", "search", "john@example.com", "--exact"]
         )
@@ -745,7 +748,8 @@ class TestCLI:
         # Mock the execute chain to return empty list
         mock_result = mocker.MagicMock()
         mock_result.scalars.return_value.all.return_value = []
-        mock_session.return_value.__aenter__.return_value.execute.return_value = mock_result
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.return_value = mock_result
         result = runner.invoke(app, ["user", "search", "nonexistent"])
         assert result.exit_code == 0
 
@@ -772,7 +776,8 @@ class TestCLI:
         # Mock the execute chain to return test_user
         mock_result = mocker.MagicMock()
         mock_result.scalars.return_value.all.return_value = [test_user]
-        mock_session.return_value.__aenter__.return_value.execute.return_value = mock_result
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.return_value = mock_result
 
         result = runner.invoke(
             app, ["user", "search", "test", "--field", "invalid_field"]
@@ -796,9 +801,8 @@ class TestCLI:
         mock_session = mocker.patch(
             self.patch_async_session,
         )
-        mock_session.return_value.__aenter__.return_value.execute.side_effect = SQLAlchemyError(
-            "Database connection failed"
-        )
+        mock_execute = mock_session.return_value.__aenter__.return_value.execute
+        mock_execute.side_effect = SQLAlchemyError("Database connection failed")
 
         result = runner.invoke(app, ["user", "search", "test"])
         assert result.exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-mail" },
+    { name = "fastapi-pagination" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "libpass", extra = ["bcrypt"] },
@@ -149,6 +150,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4" },
     { name = "fastapi-mail", specifier = ">=1.4.1" },
+    { name = "fastapi-pagination", specifier = ">=0.12.34" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "libpass", extras = ["bcrypt"], specifier = ">=1.9.0" },
@@ -832,6 +834,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/2b/a743bd324d640201c3ce2dcea4acb143058926ed3e7bfbea08304075b5c5/fastapi_mail-1.4.2.tar.gz", hash = "sha256:04bde1005c624f42dfc0a9c1e313fcc544499fdd6b3531e606c500d80ac2ffcb", size = 13353 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/ee/5d154eb4621d6a037e139a32bc1244ba8cb78a7aca9d438b56e24552203c/fastapi_mail-1.4.2-py3-none-any.whl", hash = "sha256:3525cf342ff91f6bcb3298570d1783498082e586957f668ee4164a0aab6ec743", size = 14748 },
+]
+
+[[package]]
+name = "fastapi-pagination"
+version = "0.12.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/4d/6e695098ce33b3394cf26b335ca4ec6407f9421cfdf9ad6a38775580db21/fastapi_pagination-0.12.34.tar.gz", hash = "sha256:05ee8c0bc572072160f7f30900bfd87869e1880c87bc5797922fec2e49e65f11", size = 26901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/f3/a0a1e7efd88dba07743665d1f6f88008c9a1e174458581ecaa53b8699a7c/fastapi_pagination-0.12.34-py3-none-any.whl", hash = "sha256:089d1078aae1784395b4dbd923d0c8246641ddcc291c5ec6d92a30edb92ecbdd", size = 43308 },
 ]
 
 [[package]]


### PR DESCRIPTION
add a `/search` endpoint to search the Users by email, first or last names. Also adds a `user search` command to the CLI.