### PR TITLE
CLI: add a command to populate test users into the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ docs/CNAME
 .python-version
 .changelog_generator.toml
 .envrc
+.clinerules

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ following advantages to starting your own from scratch :
   can easily be modified to add your own functionality (for example bulk add
   data) since it is based on the excellent
   [Typer][typer] library.
+- Easily add test users to the database for testing/development purposes using
+  the CLI.
 - Database and Secrets are automatically read from Environment variables or a
   `.env` file if that is provided.
 - User email is validated for correct format on creation (however no checks are

--- a/app/commands/db.py
+++ b/app/commands/db.py
@@ -128,7 +128,7 @@ def populate(
         5,
         "--count",
         "-c",
-        help="Number of users to create (default: 5)",
+        help="Number of users to create",
     ),
 ) -> None:
     """Populate the database with random test users.

--- a/app/commands/db.py
+++ b/app/commands/db.py
@@ -1,11 +1,21 @@
 """CLI command to control the Database."""
 
+import random
+from asyncio import run as aiorun
 from typing import Optional
 
 import typer
 from alembic import command
 from alembic.config import Config
+from faker import Faker
+from fastapi import HTTPException
 from rich import print as rprint
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.db import async_session
+from app.managers.user import ErrorMessages, UserManager
+from app.models.enums import RoleType
 
 app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich")
 
@@ -92,3 +102,188 @@ def revision(
     rprint()
     command.revision(ALEMBIC_CFG, message=message, autogenerate=True)
     command.upgrade(ALEMBIC_CFG, "head")
+
+
+def calc_admin_count(count: int) -> tuple[int, int]:
+    """Calculate the number of admin users to create."""
+    if count < 1:
+        rprint("[red]Error: count must be greater than 0")
+        raise typer.Exit(1)
+
+    # Calculate number of admins (1 per 5 users, max 3)
+    # Special case: if count=1, create a regular user not an admin
+    if count == 1:
+        num_admins = 0
+        num_regular_users = 1
+    else:
+        num_admins = min(count // 5 + (1 if count % 5 > 0 else 0), 3)
+        num_regular_users = count - num_admins
+
+    return num_admins, num_regular_users
+
+
+@app.command()
+def populate(
+    count: int = typer.Option(
+        5,
+        "--count",
+        "-c",
+        help="Number of users to create (default: 5)",
+    ),
+) -> None:
+    """Populate the database with random test users.
+
+    This will create the specified number of users with random data. At least 1
+    admin will be created for every 5 users, up to a maximum of 3 admins.
+    """
+    num_admins, num_regular_users = calc_admin_count(count)
+
+    rprint(
+        f"\nCreating {num_regular_users} regular users "
+        f"and {num_admins} admins..."
+    )
+
+    # Run the async function to populate the database
+    aiorun(_populate_db(num_regular_users, num_admins))
+
+    rprint(DONE_MSG)
+
+
+async def _create_single_user(
+    fake: Faker,
+    session: AsyncSession,
+    max_retries: int = 5,
+    *,
+    is_admin: bool = False,
+) -> bool:
+    """Create a single user with retry logic for duplicate emails."""
+    retries = 0
+
+    # List of common email domains
+    domains = [
+        "gmail.com",
+        "yahoo.com",
+        "hotmail.com",
+        "outlook.com",
+        "icloud.com",
+        "example.com",
+        "company.com",
+        "fastmail.com",
+        "protonmail.com",
+        "mail.com",
+        "aol.com",
+        "zoho.com",
+    ]
+
+    # Email patterns to use with first and last names
+    # {f} = first name,
+    # {l} = last name,
+    # {fi} = first initial,
+    # {li} = last initial
+    email_patterns = [
+        "{f}.{l}@{d}",  # john.doe@gmail.com
+        "{f}{l}@{d}",  # johndoe@gmail.com
+        "{fi}.{l}@{d}",  # j.doe@gmail.com
+        "{f}{li}@{d}",  # johnd@gmail.com
+        "{f}_{l}@{d}",  # john_doe@gmail.com
+        "{f}.{l}2023@{d}",  # john.doe2023@gmail.com
+        "{f}{l}123@{d}",  # johndoe123@gmail.com
+    ]
+
+    while retries < max_retries:
+        try:
+            # Generate name data
+            first_name = fake.first_name()
+            last_name = fake.last_name()
+
+            # Generate email based on name
+            domain = random.choice(domains)  # noqa: S311
+            pattern = random.choice(email_patterns)  # noqa: S311
+
+            email = pattern.format(
+                f=first_name.lower(),
+                l=last_name.lower(),
+                fi=first_name[0].lower(),
+                li=last_name[0].lower(),
+                d=domain,
+            )
+
+            user_data = {
+                "email": email,
+                "first_name": first_name,
+                "last_name": last_name,
+                "password": "Password123!",  # Default password for test users
+                "role": RoleType.admin if is_admin else RoleType.user,
+            }
+
+            await UserManager.register(user_data, session)
+
+            user_type = "admin" if is_admin else "regular user"
+            rprint(f"  Created {user_type}: {user_data['email']}")
+
+        except HTTPException as exc:  # noqa: PERF203
+            # If it's a duplicate email error, retry with a new email
+            if exc.detail == ErrorMessages.EMAIL_EXISTS:
+                retries += 1
+                if retries < max_retries:
+                    rprint(
+                        "  [yellow]Email already exists, retrying... "
+                        f"({retries}/{max_retries})"
+                    )
+                else:
+                    rprint(
+                        "  [red]Failed to create user after "
+                        f"{max_retries} attempts"
+                    )
+                    return False
+            else:
+                # For other HTTP exceptions, raise them
+                rprint(f"\n[red]-> ERROR adding user: [bold]{exc.detail}\n")
+                return False
+
+        except SQLAlchemyError as exc:
+            rprint(f"\n[red]-> Database error adding user: [bold]{exc}\n")
+            return False
+        else:
+            return True
+
+    # we should never reach this point but it simplifies typing
+    return False  # pragma: no cover
+
+
+async def _populate_db(num_regular_users: int, num_admins: int) -> None:
+    """Populate the database with random users."""
+    # Initialize Faker
+    fake = Faker()
+
+    try:
+        async with async_session() as session:
+            # Create admin users
+            admin_count = 0
+            for _ in range(num_admins):
+                success = await _create_single_user(
+                    fake, session, is_admin=True
+                )
+                if success:
+                    admin_count += 1
+
+            # Create regular users
+            user_count = 0
+            for _ in range(num_regular_users):
+                success = await _create_single_user(
+                    fake, session, is_admin=False
+                )
+                if success:
+                    user_count += 1
+
+            await session.commit()
+
+            # Final summary
+            rprint(
+                f"\nSuccessfully created {user_count} regular users "
+                f"and {admin_count} admins"
+            )
+
+    except SQLAlchemyError as exc:
+        rprint(f"\n[red]-> Database error: [bold]{exc}\n")
+        raise typer.Exit(1) from exc

--- a/docs/important.md
+++ b/docs/important.md
@@ -91,8 +91,8 @@ documentation][sqlalchemy-async-orm]{:target="_blank"} for more information
 ### The CLI is an installable package
 
 This means that the `api-admin` command is now a package and installed in your
-local virtual environment when you run `poetry install`. With this you can run
-the `api-admin` command from the command line anywhere inside the virtual
+local virtual environment when you run `uv sync`. With this you can run the
+`api-admin` command from the command line anywhere inside the virtual
 environment.
 
 ```bash
@@ -100,7 +100,7 @@ api-admin --help
 ```
 
 !!! warning "Pip users"
-    If you are not using Poetry, but the requirements.txt file, you will need to
+    If you are not using `uv`, but the requirements.txt file, you will need to
     run the `api-admin` command as a Python module. For example, `python -m
     api-admin`.
 
@@ -118,7 +118,7 @@ The project has moved completely over to using
 **and** Formatting.
 
 This relaces `Flake8`, `Black`, `isort` and many other tools with a single
-tool. I have set the rules quite strict also! All exisiting code passes these
+tool. I have set the rules quite strict also! All existing code passes these
 checks, or is whitelisted for a very good reason. This will be enforced for all
 PR's also. All tools are configured in the `pyproject.toml` file.
 
@@ -130,7 +130,7 @@ tool to check for type errors in the code. This will be enforced for all PR's.
 ### Dependency Updates
 
 All dependencies used are updated to the latest versions as of the `0.5.0`
-release and will be kept up to date using the GitHub Dependabot tool.
+release and will be kept up to date automatically using the `Renovate` tool.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,8 @@ following advantages to starting your own from scratch :
   can easily be modified to add your own functionality (for example bulk add
   data) since it is based on the excellent
   [Typer](https://typer.tiangolo.com/){:target="_blank"} library.
+- Easily add test users to the database for testing/development purposes using
+  the CLI.
 - Database and Secrets are automatically read from Environment variables or a
   `.env` file if that is provided.
 - User email is validated for correct format on creation (however no checks are

--- a/docs/usage/user-control.md
+++ b/docs/usage/user-control.md
@@ -131,3 +131,31 @@ $ api-admin user delete 23
 
 They will no longer be able to access the API, this CANNOT BE UNDONE. It's
 probably better to BAN a user unless you are very sure.
+
+## Populate Database with Test Users
+
+You can quickly populate your database with random test users using the `db populate` command:
+
+```console
+$ api-admin db populate
+```
+
+This will create 5 users by default (4 regular users and 1 admin). You can specify a different number of users with the `--count` or `-c` flag:
+
+```console
+$ api-admin db populate --count 10
+```
+
+The command will automatically create admin users based on the total count:
+
+- 1 admin per 5 users (rounded up)
+- Maximum of 3 admin users
+- If only 1 user is requested, it will be a regular user
+
+For example:
+
+- 5 users = 4 regular + 1 admin
+- 10 users = 8 regular + 2 admins
+- 20 users = 17 regular + 3 admins (maximum admins)
+
+All users are created with the default password `Password123!` and are automatically verified. The command generates realistic email addresses using various patterns and common email domains.

--- a/tests/cli/test_cli_db_command.py
+++ b/tests/cli/test_cli_db_command.py
@@ -1,15 +1,31 @@
 """Test the 'api-admin db' command."""
 
+# ruff: noqa: PLR2004
+import asyncio
+
+import pytest
+import typer
+from faker import Faker
+from fastapi import HTTPException
+from sqlalchemy.exc import SQLAlchemyError
 from typer.testing import CliRunner
 
 from app.api_admin import app
-from app.commands.db import ALEMBIC_CFG
+from app.commands.db import (
+    ALEMBIC_CFG,
+    _create_single_user,
+    _populate_db,
+    calc_admin_count,
+)
+from app.managers.user import ErrorMessages
 
 
 class TestCLI:
     """Test the database-related CLI commands."""
 
     command_patch_path = "app.commands.db.command"
+    populate_patch_path = "app.commands.db._populate_db"
+    aiorun_patch_path = "app.commands.db.aiorun"
 
     def test_init_no_force_cancels(self) -> None:
         """Test that running 'init' without --force cancels the operation."""
@@ -73,3 +89,302 @@ class TestCLI:
         cmd_patch.upgrade.assert_called_once_with(ALEMBIC_CFG, "head")
 
         assert result.exit_code == 0
+
+    # ------------------------------------------------------------------------ #
+    #                        test 'populate' subcommand                        #
+    # ------------------------------------------------------------------------ #
+    @pytest.mark.parametrize(
+        ("total_users", "expected_regular", "expected_admin", "test_case"),
+        [
+            # Basic cases
+            (1, 1, 0, "Single user creates no admin"),
+            (4, 3, 1, "Less than 5 users gets 1 admin"),
+            (5, 4, 1, "Exactly 5 users gets 1 admin"),
+            # Testing the 1 admin per 5 users rule
+            (6, 4, 2, "Just over 5 users gets 2 admin"),
+            (9, 7, 2, "Just under 10 users still gets 2 admin"),
+            (10, 8, 2, "10 users gets 2 admins"),
+            (14, 11, 3, "14 users gets 3 admins"),
+            # Testing the max 3 admins rule
+            (15, 12, 3, "15 users gets 3 admins"),
+            (16, 13, 3, "16 users hits max 3 admins"),
+            (20, 17, 3, "20 users stays at max 3 admins"),
+            (25, 22, 3, "25 users stays at max 3 admins"),
+            (50, 47, 3, "50 users stays at max 3 admins"),
+        ],
+    )
+    def test_admin_user_ratio_calculation(
+        self,
+        total_users: int,
+        expected_regular: int,
+        expected_admin: int,
+        test_case: str,
+    ) -> None:
+        """Test the admin to regular user ratio calculation logic.
+
+        The calculation follows these rules:
+        1. For every 5 users (or fraction thereof), create 1 admin
+        2. Maximum of 3 admin users regardless of total count
+        3. Remaining users are regular users
+        4. At least 1 regular user is created if count > 0
+        """
+        num_admins, num_regular_users = calc_admin_count(total_users)
+
+        # Verify our calculation matches expected values
+        assert num_regular_users == expected_regular, test_case
+        assert num_admins == expected_admin, test_case
+
+    def test_zero_users_raises_exit(self) -> None:
+        """Test that calc_admin_count raises typer.Exit for zero users."""
+        with pytest.raises(typer.Exit, match="1"):
+            calc_admin_count(0)
+
+    def test_negative_users_raises_exit(self) -> None:
+        """Test that calc_admin_count raises typer.Exit for negative users."""
+        with pytest.raises(typer.Exit, match="1"):
+            calc_admin_count(-1)
+
+    def test_create_single_user_function(self, mocker) -> None:
+        """Test the _create_single_user function directly."""
+        # Mock the necessary components
+        fake = Faker()
+        session_mock = mocker.MagicMock()
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            return_value=None,
+        )
+
+        result = asyncio.run(
+            _create_single_user(fake, session_mock, is_admin=True)
+        )
+
+        # Verify the result and that the correct calls were made
+        assert result is True
+        assert user_manager_mock.call_count == 1
+
+        # Check that the user data was correctly formatted
+        call_args = user_manager_mock.call_args
+        user_data = call_args.args[0]
+        assert "email" in user_data
+        assert "first_name" in user_data
+        assert "last_name" in user_data
+        assert "password" in user_data
+        assert user_data["password"] == "Password123!"  # noqa: S105
+
+    def test_create_single_user_duplicate_email(self, mocker) -> None:
+        """Test the _create_single_user function with duplicate email error."""
+        # Mock the necessary components
+        fake = Faker()
+        session_mock = mocker.MagicMock()
+
+        # Mock UserManager.register to raise HTTPException for duplicate email
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=[
+                HTTPException(
+                    status_code=400, detail=ErrorMessages.EMAIL_EXISTS
+                ),
+                None,  # Second call succeeds
+            ],
+        )
+
+        result = asyncio.run(
+            _create_single_user(fake, session_mock, is_admin=False)
+        )
+
+        # Verify the result and that the correct calls were made
+        assert result is True
+
+        # Called twice due to retry after duplicate email error
+        assert user_manager_mock.call_count == 2
+
+    def test_create_single_user_other_http_error(self, mocker) -> None:
+        """Test the _create_single_user function with other HTTP error."""
+        # Mock the necessary components
+        fake = Faker()
+        session_mock = mocker.MagicMock()
+
+        # Mock UserManager.register to raise HTTPException for other error
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=HTTPException(status_code=500, detail="Server error"),
+        )
+
+        result = asyncio.run(
+            _create_single_user(fake, session_mock, is_admin=False)
+        )
+
+        # Verify the result and that the correct calls were made
+        assert result is False
+        assert user_manager_mock.call_count == 1
+
+    # @pytest.mark.skip("Needs work")
+    def test_create_single_user_sqlalchemy_error(self, mocker) -> None:
+        """Test the _create_single_user function with SQLAlchemy error."""
+        # Mock the necessary components
+        fake = Faker()
+        session_mock = mocker.MagicMock()
+
+        # Mock UserManager.register to raise SQLAlchemyError
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=SQLAlchemyError("Database error"),
+        )
+
+        result = asyncio.run(
+            _create_single_user(fake, session_mock, is_admin=False)
+        )
+
+        # Verify the result and that the correct calls were made
+        assert result is False
+        assert user_manager_mock.call_count == 1
+
+    def test_create_single_user_max_retries_exceeded(self, mocker) -> None:
+        """Test the _create_single_user function with max retries exceeded."""
+        # Mock the necessary components
+        fake = Faker()
+        session_mock = mocker.MagicMock()
+
+        # Mock UserManager.register to always raise duplicate email error
+
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=HTTPException(
+                status_code=400, detail=ErrorMessages.EMAIL_EXISTS
+            ),
+        )
+
+        result = asyncio.run(
+            _create_single_user(
+                fake, session_mock, max_retries=2, is_admin=False
+            )
+        )
+
+        # Verify the result and that the correct calls were made
+        assert result is False
+        assert (
+            user_manager_mock.call_count == 2
+        )  # Called twice due to retry limit
+
+    def test_populate_command(self, mocker) -> None:
+        """Test the populate command with default count."""
+        # Mock _populate_db
+        populate_mock = mocker.patch(self.populate_patch_path, autospec=True)
+
+        # Run the command with default count (5)
+        result = CliRunner().invoke(app, ["db", "populate"])
+
+        # Verify output and success
+        assert result.exit_code == 0
+        assert "Creating 4 regular users and 1 admin" in result.output
+        assert "Done!" in result.output
+
+        # Verify _populate_db was called with correct arguments
+        populate_mock.assert_called_once_with(4, 1)
+
+    def test_populate_command_custom_count(self, mocker) -> None:
+        """Test the populate command with custom count."""
+        # Mock _populate_db
+        populate_mock = mocker.patch(self.populate_patch_path, autospec=True)
+
+        # Run the command with custom count
+        result = CliRunner().invoke(app, ["db", "populate", "-c", "9"])
+
+        # Verify output and success
+        assert result.exit_code == 0
+        assert "Creating 7 regular users and 2 admins" in result.output
+        assert "Done!" in result.output
+
+        # Verify _populate_db was called with correct arguments
+        populate_mock.assert_called_once_with(7, 2)
+
+
+@pytest.mark.asyncio
+class TestPopulateDB:
+    """Test the _populate_db function."""
+
+    async def test_successful_population(self, mocker) -> None:
+        """Test successful population with both regular and admin users."""
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+
+        # Mock async_session to return our mock session
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock _create_single_user to always succeed
+        mocker.patch(
+            "app.commands.db._create_single_user",
+            side_effect=[True] * 5,  # 3 regular users + 2 admins
+        )
+
+        # Run the populate function
+        await _populate_db(3, 2)  # 3 regular users, 2 admins
+
+        # Verify session was committed
+        session_mock.commit.assert_called_once()
+
+    async def test_database_error(self, mocker) -> None:
+        """Test database error handling."""
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+
+        # Mock async_session to return our mock session
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock session.commit to raise SQLAlchemyError
+        session_mock.commit.side_effect = SQLAlchemyError("Database error")
+
+        # Mock _create_single_user to succeed
+        mocker.patch(
+            "app.commands.db._create_single_user",
+            return_value=True,
+        )
+
+        # Run the populate function and check for typer.Exit
+        with pytest.raises(typer.Exit, match="1"):
+            await _populate_db(1, 1)
+
+    async def test_partial_success(self, mocker) -> None:
+        """Test when some users fail to create."""
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+
+        # Mock async_session to return our mock session
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock _create_single_user to fail for some users
+        mocker.patch(
+            "app.commands.db._create_single_user",
+            side_effect=[True, False, True],  # 2 succeed, 1 fails
+        )
+
+        # Run the populate function
+        await _populate_db(2, 1)  # 2 regular users, 1 admin
+
+        # Verify session was committed
+        session_mock.commit.assert_called_once()
+
+    async def test_session_management(self, mocker) -> None:
+        """Test proper session handling."""
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+
+        # Mock async_session to return our mock session
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock _create_single_user
+        mocker.patch(
+            "app.commands.db._create_single_user",
+            return_value=True,
+        )
+
+        # Run the populate function
+        await _populate_db(1, 1)
+
+        # Verify session context manager was used correctly
+        session_mock.__aenter__.assert_called_once()
+        session_mock.__aexit__.assert_called_once()


### PR DESCRIPTION
add a CLI command `db populate` which creates 5 test users (1 admin, 4 standard users) for testing and development purposes. All users will have the same password of `Password123!`

You can also add a `--count` flag to specify exactly how many users to create. In this case, it will create 1 admin for every 5-user group, up to a maximum of 3 users.