### PR TITLE
add a 'seed' command to the 'db' group in the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ docs/CNAME
 .clinerules
 .cursorrules
 .windsurfrules
+users.seed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ with Authorization already baked-in.
 
 <!-- Full documentation is now availiable on it's own page [here][doc]. Please visit
 this for full usage information, how-to's and more. -->
+
 Documentation for this project is now availiable on it's own page at
 [https://api-template.seapagan.net][doc]. This is a work in progress, and when
 finished will include full usage information and how-to's.
@@ -79,9 +80,8 @@ following advantages to starting your own from scratch :
 - Baked-in User database and management. Routes are provided to
   add/edit/delete/search or ban (and unban) Users.
 - Postgresql Integration, using SQLAlchemy ORM, no need for raw SQL queries
-  (unless you want to!). All database usage is Asynchronous.
-  [Alembic][alembic] is used to control database
-  migrations.
+  (unless you want to!). All database usage is Asynchronous. [Alembic][alembic]
+  is used to control database migrations.
 - Register and Login routes provided, both of which return a JWT token to be
   used in all future requests. JWT Token expires 120 minutes after issue.
 - JWT-based security as a Bearer Token to control access to all your routes.
@@ -100,18 +100,18 @@ following advantages to starting your own from scratch :
 - **A command-line admin tool**. This allows to configure the project metadata
   very easily, add users (and make admin), and run a development server. This
   can easily be modified to add your own functionality (for example bulk add
-  data) since it is based on the excellent
-  [Typer][typer] library.
+  data) since it is based on the excellent [Typer][typer] library.
 - Easily batch-add random test users to the database for testing/development
-  purposes using the CLI.
+  purposes using the CLI or seed the database with pre-set users from a CSV
+  file.
 - Database and Secrets are automatically read from Environment variables or a
   `.env` file if that is provided.
 - User email is validated for correct format on creation (however no checks are
   performed to ensure the email or domain actually exists).
 - Control permitted CORS Origin through Environment variables.
 - Manager class set up to send emails to users, and by default an email is sent
-  when new users register. The content is set by a template (currently a
-  basic placeholder). This email has a link for the user to confirm their email
+  when new users register. The content is set by a template (currently a basic
+  placeholder). This email has a link for the user to confirm their email
   address - until this is done, the user cannot user the API.
 - Docker and Compose file set up to develop and test this API using Docker
 
@@ -141,8 +141,8 @@ For those who let me know they are using this Template, I'll add links back to
 your project in this documentation.
 
 If this template saves you time/effort/money, or you just wish to show your
-appreciation for my work, why not [Sponsor my
-Work][sponsor] or [Buy me a Coffee!][coffee] 😃
+appreciation for my work, why not [Sponsor my Work][sponsor] or [Buy me a
+Coffee!][coffee] 😃
 
 ## Installation
 
@@ -286,27 +286,22 @@ See [Contributing][contrib] for details on how to contribute to this project.
 
 ## GitHub Discussions
 
-I have enabled
-[Discussions][discussions] on this
-repository, so if you have any questions, suggestions or just want to chat about
-this template, please feel free to start a discussion.
+I have enabled [Discussions][discussions] on this repository, so if you have any
+questions, suggestions or just want to chat about this template, please feel
+free to start a discussion.
 
-[doc]:https://api-template.seapagan.net
-[contrib]:https://api-template.seapagan.net/contributing/
-[breaking]:https://api-template.seapagan.net/important/
-[install]:https://api-template.seapagan.net/usage/installation/
-[latest-release]:https://github.com/seapagan/fastapi-template/releases/latest
-[discussions]:https://github.com/seapagan/fastapi-template/discussions
-
-[legacy-branch]:https://github.com/seapagan/fastapi-template/tree/0.4.2
-
-[sponsor]:https://github.com/sponsors/seapagan
-[coffee]:https://www.buymeacoffee.com/seapagan
-
+[doc]: https://api-template.seapagan.net
+[contrib]: https://api-template.seapagan.net/contributing/
+[breaking]: https://api-template.seapagan.net/important/
+[install]: https://api-template.seapagan.net/usage/installation/
+[latest-release]: https://github.com/seapagan/fastapi-template/releases/latest
+[discussions]: https://github.com/seapagan/fastapi-template/discussions
+[legacy-branch]: https://github.com/seapagan/fastapi-template/tree/0.4.2
+[sponsor]: https://github.com/sponsors/seapagan
+[coffee]: https://www.buymeacoffee.com/seapagan
 [alembic]: https://github.com/sqlalchemy/alembic
-[typer]:https://typer.tiangolo.com/
-[fastapi]:https://fastapi.tiangolo.com/
-[pytest]:https://docs.pytest.org
-
-[tut-basic]:https://fastapi.tiangolo.com/tutorial/
-[tut-advanced]:https://fastapi.tiangolo.com/advanced/
+[typer]: https://typer.tiangolo.com/
+[fastapi]: https://fastapi.tiangolo.com/
+[pytest]: https://docs.pytest.org
+[tut-basic]: https://fastapi.tiangolo.com/tutorial/
+[tut-advanced]: https://fastapi.tiangolo.com/advanced/

--- a/app/commands/db.py
+++ b/app/commands/db.py
@@ -301,7 +301,6 @@ def seed(
         Path,
         typer.Argument(
             ...,
-            exists=True,
             file_okay=True,
             dir_okay=False,
             readable=True,
@@ -326,6 +325,11 @@ def seed(
     If no CSV file is specified, the command will look for 'users.seed' in the
     current directory.
     """
+    # Check if the file exists
+    if not csv_file.exists():
+        rprint(f"[red]Error: File '{csv_file}' does not exist")
+        raise typer.Exit(1)
+
     # Display which file we're using
     rprint(f"Using seed file: [green]{csv_file}")
 
@@ -336,7 +340,7 @@ def seed(
         )
         if not confirm:
             rprint("[cyan]Operation Cancelled.")
-            return
+            raise typer.Exit(0)
 
     rprint("\nImporting users from CSV file ... ")
 

--- a/app/commands/db.py
+++ b/app/commands/db.py
@@ -20,7 +20,7 @@ from app.database.db import async_session
 from app.managers.user import ErrorMessages, UserManager
 from app.models.enums import RoleType
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
 app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich")

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ following advantages to starting your own from scratch :
   or ban (and unban) Users.
 - Postgresql Integration, using SQLAlchemy ORM, no need for raw SQL queries
   (unless you want to!). All database usage is Asynchronous.
-  [Alembic](https://github.com/sqlalchemy/alembic){:target="_blank"} is used to
+  [Alembic](https://github.com/sqlalchemy/alembic){:target="\_blank"} is used to
   control database migrations.
 - Register and Login routes provided, both of which return a JWT token to be
   used in all future requests. JWT Token expires 120 minutes after issue.
@@ -62,17 +62,18 @@ following advantages to starting your own from scratch :
   very easily, add users (and make admin), and run a development server. This
   can easily be modified to add your own functionality (for example bulk add
   data) since it is based on the excellent
-  [Typer](https://typer.tiangolo.com/){:target="_blank"} library.
+  [Typer](https://typer.tiangolo.com/){:target="\_blank"} library.
 - Easily batch-add random test users to the database for testing/development
-  purposes using the CLI.
+  purposes using the CLI or seed the database with pre-set users from a CSV
+  file.
 - Database and Secrets are automatically read from Environment variables or a
   `.env` file if that is provided.
 - User email is validated for correct format on creation (however no checks are
   performed to ensure the email or domain actually exists).
 - Control permitted CORS Origin through Environment variables.
 - Manager class set up to send emails to users, and by default an email is sent
-  when new users register. The content is set by a template (currently a
-  basic placeholder). This email has a link for the user to confirm their email
+  when new users register. The content is set by a template (currently a basic
+  placeholder). This email has a link for the user to confirm their email
   address - until this is done, the user cannot user the API.
 - Docker and Compose file set up to develop and test this API using Docker
 
@@ -92,9 +93,9 @@ This project uses [Semantic Versioning 2.0.0](https://semver.org/)
 
 Given a version number `MAJOR`.`MINOR`.`PATCH`, increment the:
 
-  1. `MAJOR` version when you make incompatible API changes
-  2. `MINOR` version when you add functionality in a backward compatible manner
-  3. `PATCH` version when you make backward compatible bug fixes
+1. `MAJOR` version when you make incompatible API changes
+2. `MINOR` version when you add functionality in a backward compatible manner
+3. `PATCH` version when you make backward compatible bug fixes
 
 Additional labels for pre-release and build metadata are available as extensions
 to the MAJOR.MINOR.PATCH format.
@@ -124,8 +125,8 @@ For those who let me know they are using this Template, I'll add links back to
 your project in this documentation.
 
 If this template saves you time/effort/money, or you just wish to show your
-appreciation for my work, why not [Buy me a
-Coffee!](https://www.buymeacoffee.com/seapagan){:target="_blank"} 😃
+appreciation for my work, why not
+[Buy me a Coffee!](https://www.buymeacoffee.com/seapagan){:target="\_blank"} 😃
 
 ## Funding Link
 

--- a/docs/usage/user-control.md
+++ b/docs/usage/user-control.md
@@ -13,8 +13,8 @@ command-line.
 
 ## Add a User
 
-This is described in the [previous page](add-user.md). It is important to
-note that any user added this way will be **automatically verified**.
+This is described in the [previous page](add-user.md). It is important to note
+that any user added this way will be **automatically verified**.
 
 ## List All Users
 
@@ -65,10 +65,9 @@ Basic search (searches all fields):
 $ api-admin user search "john"
 ```
 
-!!! tip
-    The quotes around the search term are optional if the term does not contain
-    spaces. For example, both `api-admin user search john` and `api-admin user
-    search "john"` are valid.
+!!! tip The quotes around the search term are optional if the term does not
+contain spaces. For example, both `api-admin user search john` and
+`api-admin user search "john"` are valid.
 
 Search in a specific field:
 
@@ -89,7 +88,8 @@ For exact matching, use the `--exact` flag:
 $ api-admin user search "john.doe@example.com" --exact
 ```
 
-The search results will be displayed in a table showing the user's Id, Email address, First and Last name, Role, and the Verified and Banned Status.
+The search results will be displayed in a table showing the user's Id, Email
+address, First and Last name, Role, and the Verified and Banned Status.
 
 ## Ban or Unban a specific User
 
@@ -132,15 +132,68 @@ $ api-admin user delete 23
 They will no longer be able to access the API, this CANNOT BE UNDONE. It's
 probably better to BAN a user unless you are very sure.
 
+## Seed Database with Users from a File
+
+You can import users from a CSV file using the `db seed` command:
+
+```console
+$ api-admin db seed users.seed
+```
+
+This is useful for quickly populating a database with local users.
+
+By default, the command looks for a file named `users.seed` in the current
+directory, but you can specify a different file path as an argument.
+
+The CSV file should have a header row with the following columns:
+
+- `email` - User's email address (required)
+- `password` - User's password in **PLAIN TEXT** (required)
+- `first_name` - User's first name (required)
+- `last_name` - User's last name (required)
+- `role` - User's role, either 'user' or 'admin' (optional, defaults to 'user')
+
+Example `users.seed` file:
+
+```csv
+email,password,first_name,last_name,role
+john.doe@example.com,SecurePassword123!,John,Doe,user
+jane.smith@example.com,AnotherPassword456!,Jane,Smith,admin
+alex.wilson@example.com,StrongPassword789!,Alex,Wilson,user
+```
+
+!!! important
+    This seed file has passwords in **PLAIN TEXT** and should not be added
+    to source control, ESPECIALLY if they are stored in an external service like
+    GitHub.
+
+The command will:
+
+- Create new users from the CSV file
+- Skip users with email addresses that already exist in the database
+- Report any errors that occur during the import process
+- Display a summary of created users, skipped duplicates, and errors
+
+You can use the `--force` or `-f` flag to skip the confirmation prompt:
+
+```console
+$ api-admin db seed users.seed --force
+```
+
+All users created with this command are automatically verified and can log in
+immediately.
+
 ## Populate Database with Test Users
 
-You can quickly populate your database with random test users using the `db populate` command:
+You can quickly populate your database with random test users using the
+`db populate` command:
 
 ```console
 $ api-admin db populate
 ```
 
-This will create 5 users by default (4 regular users and 1 admin). You can specify a different number of users with the `--count` or `-c` flag:
+This will create 5 users by default (4 regular users and 1 admin). You can
+specify a different number of users with the `--count` or `-c` flag:
 
 ```console
 $ api-admin db populate --count 10
@@ -158,4 +211,6 @@ For example:
 - 10 users = 8 regular + 2 admins
 - 20 users = 17 regular + 3 admins (maximum admins)
 
-All users are created with the default password `Password123!` and are automatically verified. The command generates realistic email addresses using various patterns and common email domains.
+All users are created with the default password `Password123!` and are
+automatically verified. The command generates realistic email addresses using
+various patterns and common email domains.

--- a/tests/cli/test_cli_db_seed.py
+++ b/tests/cli/test_cli_db_seed.py
@@ -1,0 +1,437 @@
+"""Test the 'api-admin db seed' command."""
+
+# ruff: noqa: S105
+import csv
+from pathlib import Path
+
+import pytest
+import typer
+from fastapi import HTTPException
+from sqlalchemy.exc import SQLAlchemyError
+from typer.testing import CliRunner
+
+from app.api_admin import app
+from app.commands.db import _seed_users_from_csv, _validate_csv_file
+from app.managers.user import ErrorMessages
+from app.models.enums import RoleType
+
+
+class TestSeedCommand:
+    """Test the 'api-admin db seed' command."""
+
+    # Path to mock for the csv file operations
+    validate_csv_path = "app.commands.db._validate_csv_file"
+    seed_users_path = "app.commands.db._seed_users_from_csv"
+    aiorun_path = "app.commands.db.aiorun"
+
+    def test_seed_no_force_cancels(self, mocker) -> None:
+        """Test that running 'seed' without --force cancels the operation."""
+        # Mock the validation to return some valid rows
+        mocker.patch(
+            self.validate_csv_path,
+            return_value=[
+                {
+                    "email": "test@example.com",
+                    "password": "Password123!",
+                    "first_name": "Test",
+                    "last_name": "User",
+                    "role": "user",
+                }
+            ],
+        )
+
+        # Mock the typer.confirm to return False (user cancels)
+        mocker.patch("typer.confirm", return_value=False)
+
+        # Run the command
+        result = CliRunner().invoke(app, ["db", "seed", "users.seed"])
+
+        # Verify output and success
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_seed_with_force(self, mocker) -> None:
+        """Test that running 'seed' with --force seeds the database."""
+        # Mock the validation to return some valid rows
+        mock_rows = [
+            {
+                "email": "test@example.com",
+                "password": "Password123!",
+                "first_name": "Test",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(self.validate_csv_path, return_value=mock_rows)
+
+        # Mock the aiorun function
+        aiorun_mock = mocker.patch(self.aiorun_path)
+
+        # Run the command with --force
+        result = CliRunner().invoke(
+            app, ["db", "seed", "users.seed", "--force"]
+        )
+
+        # Verify output and success
+        assert result.exit_code == 0
+        assert "Importing users from CSV file" in result.output
+        assert "Done!" in result.output
+
+        # Verify _seed_users_from_csv was called
+        aiorun_mock.assert_called_once()
+
+    def test_seed_with_confirmation(self, mocker) -> None:
+        """Test that running 'seed' with confirmation seeds the database."""
+        # Mock the validation to return some valid rows
+        mock_rows = [
+            {
+                "email": "test@example.com",
+                "password": "Password123!",
+                "first_name": "Test",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(self.validate_csv_path, return_value=mock_rows)
+
+        # Mock the typer.confirm to return True (user confirms)
+        mocker.patch("typer.confirm", return_value=True)
+
+        # Mock the aiorun function
+        aiorun_mock = mocker.patch(self.aiorun_path)
+
+        # Run the command without --force
+        result = CliRunner().invoke(app, ["db", "seed", "users.seed"])
+
+        # Verify output and success
+        assert result.exit_code == 0
+        assert "Importing users from CSV file" in result.output
+        assert "Done!" in result.output
+
+        # Verify _seed_users_from_csv was called
+        aiorun_mock.assert_called_once()
+
+
+class TestValidateCsvFile:
+    """Test the _validate_csv_file function."""
+
+    def test_valid_csv_file(self, tmp_path) -> None:
+        """Test validating a valid CSV file."""
+        # Create a valid CSV file
+        csv_file = tmp_path / "valid.csv"
+        with csv_file.open("w", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                ["email", "password", "first_name", "last_name", "role"]
+            )
+            writer.writerow(
+                ["test@example.com", "Password123!", "Test", "User", "user"]
+            )
+
+        # Validate the CSV file
+        rows = _validate_csv_file(csv_file)
+
+        # Verify the rows were returned correctly
+        assert len(rows) == 1
+        assert rows[0]["email"] == "test@example.com"
+        assert rows[0]["password"] == "Password123!"
+        assert rows[0]["first_name"] == "Test"
+        assert rows[0]["last_name"] == "User"
+        assert rows[0]["role"] == "user"
+
+    def test_csv_file_no_header(self, tmp_path) -> None:
+        """Test validating a CSV file with no header row."""
+        # Create a CSV file with no header
+        csv_file = tmp_path / "no_header.csv"
+        with csv_file.open("w", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                ["test@example.com", "Password123!", "Test", "User", "user"]
+            )
+
+        # Validate the CSV file and expect an error
+        with pytest.raises(typer.Exit, match="1"):
+            _validate_csv_file(csv_file)
+
+    def test_csv_file_empty(self, tmp_path) -> None:
+        """Test validating an empty CSV file."""
+        # Create an empty CSV file
+        csv_file = tmp_path / "empty.csv"
+        with csv_file.open("w", encoding="utf-8"):
+            pass  # Empty file
+
+        # Validate the CSV file and expect an error
+        with pytest.raises(typer.Exit, match="1"):
+            _validate_csv_file(csv_file)
+
+    def test_csv_file_missing_required_fields(self, tmp_path) -> None:
+        """Test validating a CSV file with missing required fields."""
+        # Create a CSV file with missing required fields
+        csv_file = tmp_path / "missing_fields.csv"
+        with csv_file.open("w", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                ["email", "password"]
+            )  # Missing first_name and last_name
+            writer.writerow(["test@example.com", "Password123!"])
+
+        # Validate the CSV file and expect an error
+        with pytest.raises(typer.Exit, match="1"):
+            _validate_csv_file(csv_file)
+
+
+@pytest.mark.asyncio
+class TestSeedUsersFromCsv:
+    """Test the _seed_users_from_csv function."""
+
+    async def test_successful_import(self, mocker) -> None:
+        """Test successful import of users from CSV."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "user1@example.com",
+                "password": "Password123!",
+                "first_name": "User",
+                "last_name": "One",
+                "role": "user",
+            },
+            {
+                "email": "admin@example.com",
+                "password": "Password123!",
+                "first_name": "Admin",
+                "last_name": "User",
+                "role": "admin",
+            },
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock UserManager.register
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register", return_value=None
+        )
+
+        # Run the function
+        await _seed_users_from_csv(Path("dummy.csv"))
+
+        # Verify the correct calls were made
+        assert user_manager_mock.call_count == 2  # noqa: PLR2004
+
+        # Check that the user data was correctly formatted
+        calls = user_manager_mock.call_args_list
+
+        # First user (regular)
+        user_data = calls[0].args[0]
+        assert user_data["email"] == "user1@example.com"
+        assert user_data["password"] == "Password123!"
+        assert user_data["first_name"] == "User"
+        assert user_data["last_name"] == "One"
+        assert user_data["role"] == RoleType.user
+
+        # Second user (admin)
+        admin_data = calls[1].args[0]
+        assert admin_data["email"] == "admin@example.com"
+        assert admin_data["password"] == "Password123!"
+        assert admin_data["first_name"] == "Admin"
+        assert admin_data["last_name"] == "User"
+        assert admin_data["role"] == RoleType.admin
+
+        # Verify session was committed twice (once for each user)
+        assert session_mock.commit.call_count == 2  # noqa: PLR2004
+
+    async def test_duplicate_email(self, mocker) -> None:
+        """Test handling of duplicate email during import."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "duplicate@example.com",
+                "password": "Password123!",
+                "first_name": "Duplicate",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock UserManager.register to raise HTTPException for duplicate email
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=HTTPException(
+                status_code=400, detail=ErrorMessages.EMAIL_EXISTS
+            ),
+        )
+
+        # Run the function
+        await _seed_users_from_csv(Path("dummy.csv"))
+
+        # Verify the correct calls were made
+        assert user_manager_mock.call_count == 1
+
+        # Verify session was rolled back
+        assert session_mock.rollback.call_count == 1
+        assert session_mock.commit.call_count == 0
+
+    async def test_http_exception(self, mocker) -> None:
+        """Test handling of other HTTP exceptions during import."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "error@example.com",
+                "password": "Password123!",
+                "first_name": "Error",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock UserManager.register to raise HTTPException
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=HTTPException(
+                status_code=400, detail="Some other error"
+            ),
+        )
+
+        # Run the function
+        await _seed_users_from_csv(Path("dummy.csv"))
+
+        # Verify the correct calls were made
+        assert user_manager_mock.call_count == 1
+
+        # Verify session was rolled back
+        assert session_mock.rollback.call_count == 1
+        assert session_mock.commit.call_count == 0
+
+    async def test_value_error(self, mocker) -> None:
+        """Test handling of ValueError during import."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "error@example.com",
+                "password": "Password123!",
+                "first_name": "Error",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock UserManager.register to raise ValueError
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=ValueError("Invalid data"),
+        )
+
+        # Run the function
+        await _seed_users_from_csv(Path("dummy.csv"))
+
+        # Verify the correct calls were made
+        assert user_manager_mock.call_count == 1
+
+        # Verify session was rolled back
+        assert session_mock.rollback.call_count == 1
+        assert session_mock.commit.call_count == 0
+
+    async def test_sqlalchemy_error(self, mocker) -> None:
+        """Test handling of SQLAlchemyError during import."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "error@example.com",
+                "password": "Password123!",
+                "first_name": "Error",
+                "last_name": "User",
+                "role": "user",
+            }
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.return_value = session_mock
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Mock UserManager.register to raise SQLAlchemyError
+        user_manager_mock = mocker.patch(
+            "app.commands.db.UserManager.register",
+            side_effect=SQLAlchemyError("Database error"),
+        )
+
+        # Run the function
+        await _seed_users_from_csv(Path("dummy.csv"))
+
+        # Verify the correct calls were made
+        assert user_manager_mock.call_count == 1
+
+        # Verify session was rolled back
+        assert session_mock.rollback.call_count == 1
+        assert session_mock.commit.call_count == 0
+
+    async def test_global_sqlalchemy_error(self, mocker) -> None:
+        """Test handling of global SQLAlchemyError during import."""
+        # Mock the _validate_csv_file function
+        mock_rows = [
+            {
+                "email": "user@example.com",
+                "password": "Password123!",
+                "first_name": "User",
+                "last_name": "Test",
+                "role": "user",
+            }
+        ]
+        mocker.patch(
+            "app.commands.db._validate_csv_file", return_value=mock_rows
+        )
+
+        # Mock the session context manager to raise SQLAlchemyError
+        session_mock = mocker.AsyncMock()
+        session_mock.__aenter__.side_effect = SQLAlchemyError(
+            "Global database error"
+        )
+        mocker.patch("app.commands.db.async_session", return_value=session_mock)
+
+        # Run the function and expect an error
+        with pytest.raises(typer.Exit, match="1"):
+            await _seed_users_from_csv(Path("dummy.csv"))
+
+    async def test_general_exception(self, mocker) -> None:
+        """Test handling of general exceptions during import."""
+        # Mock the _validate_csv_file function to raise an exception
+        mocker.patch(
+            "app.commands.db._validate_csv_file",
+            side_effect=Exception("Unexpected error"),
+        )
+
+        # Run the function and expect an error
+        with pytest.raises(typer.Exit, match="1"):
+            await _seed_users_from_csv(Path("dummy.csv"))


### PR DESCRIPTION
Allow seeding the database with data (say your admin users and dev/test team) simply using a seed file in CSV format.

You can specify a file, or it will default to `users.seed` in the current folder.

> [!IMPORTANT]
>
> This seed file should obviously NOT be checked into source control if it is public!! The project `.gitignore` contains the default `users.seed` file already.

Example file:

```csv
email,password,first_name,last_name,role
admin@example.com,AdminPassword123!,Admin,User,admin
john.doe@example.com,SecurePass456!,John,Doe,user
jane.smith@example.com,StrongPass789!,Jane,Smith,user
tech.lead@example.com,LeadPass321!,Tech,Lead,admin
support@example.com,SupportPass987!,Support,Team,user
```

As seen above, the first row is compulsory and lists the columns, except the role column is optional and will default to "user" if skipped or invalid

There are 4 tests that fail only under python 3.9, and it's a case of wrong return code in the CLI under missing file situations. Running it works fine so I'm not going to spend more time trying to troubleshoot this. They are marked as `xfail` only under Python < 3.10