### PR TITLE
feat: implement HMAC-SHA256 for API key hashing

### DIFF
--- a/app/managers/api_key.py
+++ b/app/managers/api_key.py
@@ -1,6 +1,7 @@
 """Define the API Key Manager."""
 
 import hashlib
+import hmac
 import secrets
 from typing import Optional
 from uuid import UUID
@@ -8,6 +9,7 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config.settings import get_settings
 from app.database.db import get_database
 from app.database.helpers import (
     add_new_api_key_,
@@ -36,8 +38,17 @@ class ApiKeyManager:
 
     @staticmethod
     def _hash_key(key: str) -> str:
-        """Hash an API key."""
-        return hashlib.sha256(key.encode()).hexdigest()
+        """Hash an API key using HMAC-SHA256.
+
+        This intentionally uses HMAC-SHA256 rather than a slow, memory-hard
+        password hash (e.g., bcrypt or argon2) because our API keys are
+        generated with `secrets.token_urlsafe(32)`, giving ~192 bits of
+        entropy. They are not human-chosen or guessable, so brute-forcing
+        them is computationally infeasible. HMAC also prevents
+        length-extension attacks possible with raw SHA256 hashing.
+        """
+        secret_key = get_settings().secret_key.encode()
+        return hmac.new(secret_key, key.encode(), hashlib.sha256).hexdigest()
 
     @classmethod
     def generate_key(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ convention = "google"
   "TD003",
   "FIX002",
   "RUF012",
+  "SLF001", # sometimes tests need to access private members
 ]
 "app/managers/auth.py" = ["ERA001"]
 "app/resources/auth.py" = ["ERA001"]

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,6 +1,5 @@
 """Unit tests for the admin interface."""
 
-# ruff: noqa: SLF001
 import json
 from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
This uses the existing secret key (used in JWT) and is more secure than the original plain SHA256. hopefully will gix a CodeQL error