### PR TITLE
feat: add manual database session handling with rollback on exception

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -79,3 +79,17 @@ async def get_database() -> AsyncGenerator[AsyncSession, Any]:
     """Return the database connection as a Generator."""
     async with async_session() as session, session.begin():
         yield session
+
+
+async def get_database_manual() -> AsyncGenerator[AsyncSession, Any]:
+    """Return a MANUAL database session as a generator.
+
+    This will need an explicit `db.commit` call for any route using it, but
+    should allow multiple database calls in the same route.
+    """
+    async with async_session() as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise


### PR DESCRIPTION
Add a second database dependency that will NOT call the explicit `.begin()` on the session, so the session will only be opened when first accessed and should allow multiple database calls in the same route.

Should allow closing #768 

In future this may be the default functionality but for now lets leave the auto-commit dependency as default.