### PR TITLE
modify renovate-bot config slightly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "lockFileMaintenance": {
-    "enabled": true
+    // this creates too much noise and failed PR tests by trying to update too
+    // much, ie even internal packages dependencies. Nice idea, but better to do
+    // by hand.
+    "enabled": false
   },
   "extends": [
     "config:recommended"
@@ -17,7 +20,5 @@
     "pep621",
     "github-actions"
   ],
-  "ignoreDeps": [
-    "pytest-asyncio"
-  ]
+  "ignoreDeps": []
 }


### PR DESCRIPTION
- remove the `ignoreDeps` setting for `pytest-asyncio` - we can update that now.
- disable `lockFileMaintenance` as it tries to update even deps of third-party packages which can cause test and code failures. Will continue to do this by hand for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to disable automatic lock file maintenance and added explanatory documentation.
  * Adjusted the dependency ignore list to enable management updates for previously exempted packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->