### PR TITLE
Update Typer to 0.24.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,9 @@ aiosqlite==0.21.0
 alembic==1.17.2
     # via api-template
 annotated-doc==0.0.4
-    # via fastapi
+    # via
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
     # via pydantic
 anyio==4.8.0
@@ -64,7 +66,7 @@ cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     #   pynacl
 charset-normalizer==3.4.1
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   mkdocs
     #   rich-toolkit
@@ -436,7 +438,7 @@ toolz==1.0.0
 tqdm==4.67.1
     # via openai
 ty==0.0.24
-typer==0.16.0
+typer==0.24.1
     # via
     #   api-template
     #   fastapi-cli
@@ -477,7 +479,6 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   sqlalchemy
     #   starlette
-    #   typer
     #   typing-inspection
     #   uvicorn
 typing-inspection==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ aiosmtplib==5.0.0
 alembic==1.17.2
     # via api-template
 annotated-doc==0.0.4
-    # via fastapi
+    # via
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
     # via pydantic
 anyio==4.8.0
@@ -37,7 +39,7 @@ certifi==2025.1.31
     #   sentry-sdk
 cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
-click==8.1.8
+click==8.3.1
     # via
     #   rich-toolkit
     #   typer
@@ -210,7 +212,7 @@ starlette==0.50.0
     #   sqladmin
 tomli==2.2.1 ; python_full_version < '3.11'
     # via alembic
-typer==0.16.0
+typer==0.24.1
     # via
     #   api-template
     #   fastapi-cli
@@ -232,7 +234,6 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   sqlalchemy
     #   starlette
-    #   typer
     #   typing-inspection
     #   uvicorn
 typing-inspection==0.4.2

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -1,0 +1,7 @@
+"""Some constants duplicated throughout test files.
+
+For now there is only one, this is just future-proofing.
+"""
+
+# exit code from typer (via click) when no args are passed and help is shown.
+CLICK_NO_ARGS_HELP_EXIT_CODE = 2

--- a/tests/cli/test_cli_create_user.py
+++ b/tests/cli/test_cli_create_user.py
@@ -55,6 +55,7 @@ class TestCLI:
                 "--password",
                 fake_user_data["password"],
             ],
+            input="n\n",
         )
         assert result.exit_code == 0
         assert "added successfully" in result.output
@@ -112,6 +113,7 @@ class TestCLI:
                 "--password",
                 fake_user_data["password"],
             ],
+            input="n\n",
         )
         assert result.exit_code == 1
         assert "ERROR adding User" in result.output
@@ -139,6 +141,7 @@ class TestCLI:
                 "--password",
                 fake_user_data["password"],
             ],
+            input="n\n",
         )
         assert result.exit_code == 1
         assert "ERROR adding User" in result.output
@@ -150,7 +153,7 @@ class TestCLI:
         user_input = (
             f"{fake_user_data['email']}\n{fake_user_data['first_name']}\n"
             f"{fake_user_data['last_name']}\n{fake_user_data['password']}\n"
-            f"{fake_user_data['password']}\n"
+            f"{fake_user_data['password']}\nNo\n"
         )
 
         mock_register = mocker.patch(

--- a/tests/cli/test_cli_custom_command.py
+++ b/tests/cli/test_cli_custom_command.py
@@ -21,6 +21,7 @@ from app.commands.custom import (
     init,
 )
 from app.config.helpers import LICENCES
+from tests._constants import CLICK_NO_ARGS_HELP_EXIT_CODE
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -96,7 +97,7 @@ authors = [{name='Old Author',email='oldauthor@example.com'}]""",
     def test_no_command_should_give_help(self, runner: CliRunner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, ["custom"])
-        assert result.exit_code == 0
+        assert result.exit_code == CLICK_NO_ARGS_HELP_EXIT_CODE
 
         command_list = ["metadata"]
 

--- a/tests/cli/test_cli_db_command.py
+++ b/tests/cli/test_cli_db_command.py
@@ -29,7 +29,7 @@ class TestCLI:
 
     def test_init_no_force_cancels(self) -> None:
         """Test that running 'init' without --force cancels the operation."""
-        result = CliRunner().invoke(app, ["db", "init"])
+        result = CliRunner().invoke(app, ["db", "init"], input="n\n")
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
@@ -46,7 +46,7 @@ class TestCLI:
 
     def test_drop_no_force_cancels(self) -> None:
         """Test that running 'drop' without --force cancels the operation."""
-        result = CliRunner().invoke(app, ["db", "drop"])
+        result = CliRunner().invoke(app, ["db", "drop"], input="n\n")
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 

--- a/tests/cli/test_cli_docs_command.py
+++ b/tests/cli/test_cli_docs_command.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
 from app.api_admin import app
+from tests._constants import CLICK_NO_ARGS_HELP_EXIT_CODE
 
 
 class TestCLI:
@@ -15,7 +16,7 @@ class TestCLI:
     def test_no_command_should_give_help(self, runner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, ["docs"])
-        assert result.exit_code == 0
+        assert result.exit_code == CLICK_NO_ARGS_HELP_EXIT_CODE
 
         command_list = ["openapi"]
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -3,6 +3,7 @@
 import pytest
 
 from app.api_admin import app, cli_header
+from tests._constants import CLICK_NO_ARGS_HELP_EXIT_CODE
 
 
 class TestCLI:
@@ -38,7 +39,7 @@ class TestCLI:
     def test_no_command_should_give_help(self, runner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, [])
-        assert result.exit_code == 0
+        assert result.exit_code == CLICK_NO_ARGS_HELP_EXIT_CODE
 
         command_list = ["custom", "db", "docs", "serve", "test", "user"]
 

--- a/tests/cli/test_cli_test_command.py
+++ b/tests/cli/test_cli_test_command.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from app.api_admin import app
 from app.database.db import Base
+from tests._constants import CLICK_NO_ARGS_HELP_EXIT_CODE
 
 
 class TestCLI:
@@ -15,7 +16,7 @@ class TestCLI:
     def test_no_command_should_give_help(self, runner: CliRunner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, ["test"])
-        assert result.exit_code == 0
+        assert result.exit_code == CLICK_NO_ARGS_HELP_EXIT_CODE
 
         command_list = ["setup"]
 

--- a/tests/cli/test_cli_user_command.py
+++ b/tests/cli/test_cli_user_command.py
@@ -12,6 +12,7 @@ from app.managers.user import ErrorMessages
 from app.models.enums import RoleType
 from app.models.user import User
 from app.schemas.request.user import SearchField
+from tests._constants import CLICK_NO_ARGS_HELP_EXIT_CODE
 
 
 @pytest.fixture(scope="module")
@@ -92,7 +93,7 @@ class TestCLI:
     def test_no_command_should_give_help(self, runner: CliRunner) -> None:
         """Test that running with no command should give help."""
         result = runner.invoke(app, ["user"])
-        assert result.exit_code == 0
+        assert result.exit_code == CLICK_NO_ARGS_HELP_EXIT_CODE
 
         command_list = [
             "admin",

--- a/tests/cli/test_cli_user_command.py
+++ b/tests/cli/test_cli_user_command.py
@@ -882,6 +882,7 @@ class TestCLI:
                 "--password",
                 faker.password(),
             ],
+            input="n\n",
         )
         assert result.exit_code == 1
         assert "Database has not been initialized" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -630,14 +630,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -3203,17 +3203,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.16.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update Typer to 0.24.1 and refresh the generated lock and requirements files.

This also aligns the CLI tests with the current Typer and Click behavior:
- help-with-no-command assertions now match the Click 8.2+ exit code
- prompt-driven CLI tests now provide explicit input so they exercise the intended command paths instead of aborting on EOF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core CLI framework dependencies (click and typer) to latest stable versions to improve compatibility, security, and overall framework stability.

* **Tests**
  * Enhanced test suite with improved interactive CLI input handling and standardised test constants across all CLI command tests to ensure consistent behaviour validation and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->