### PR TITLE
Add optional secrets dir support for settings

### DIFF
--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -8,7 +8,7 @@ from sqladmin import Admin
 
 from app.admin.auth import AdminAuth
 from app.admin.models import KeysAdmin, UserAdmin
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import async_session
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -17,7 +17,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def register_admin(app: FastAPI) -> None:
     """Register the admin views."""
-    authentication_backend = AdminAuth(secret_key=get_settings().secret_key)
+    authentication_backend = AdminAuth(
+        secret_key=unwrap_secret(get_settings().secret_key)
+    )
 
     if not get_settings().admin_pages_enabled:
         return

--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def register_admin(app: FastAPI) -> None:
     """Register the admin views."""
+    if not get_settings().admin_pages_enabled:
+        return
+
     authentication_backend = AdminAuth(
         secret_key=unwrap_secret(get_settings().secret_key)
     )
-
-    if not get_settings().admin_pages_enabled:
-        return
 
     admin = Admin(
         app,

--- a/app/admin/auth.py
+++ b/app/admin/auth.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from cryptography.fernet import Fernet, InvalidToken
 from sqladmin.authentication import AuthenticationBackend
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import async_session
 from app.database.helpers import (
     get_user_by_email_,
@@ -31,7 +31,10 @@ class AdminAuth(AuthenticationBackend):
         """Initialize the auth backend with encryption key."""
         super().__init__(secret_key)
         # Use the configured encryption key
-        self.fernet = Fernet(get_settings().admin_pages_encryption_key.encode())
+        encryption_key = unwrap_secret(
+            get_settings().admin_pages_encryption_key
+        )
+        self.fernet = Fernet(encryption_key.encode())
         self._timeout = get_settings().admin_pages_timeout
 
     def _create_token(self, user_id: int) -> str:

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -236,6 +236,20 @@ class Settings(BaseSettings):
             raise ValueError(msg)
         return value
 
+    @field_validator("admin_pages_encryption_key", mode="before")
+    @classmethod
+    def validate_admin_pages_encryption_key(
+        cls: type[Settings], value: SecretStr | str | None
+    ) -> SecretStr | str:
+        """Generate admin encryption key when configured value is empty."""
+        if value is None:
+            return SecretStr(Fernet.generate_key().decode())
+
+        if not unwrap_secret(value):
+            return SecretStr(Fernet.generate_key().decode())
+
+        return value
+
     @field_validator("db_password", "test_db_password")
     @classmethod
     def validate_db_password(

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from functools import lru_cache
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from urllib.parse import quote
 
@@ -300,11 +300,39 @@ class Settings(BaseSettings):
         return value
 
 
+def check_secrets_dir() -> list[str]:
+    """Validate SECRETS_DIR and return warning messages.
+
+    Returns a list of warning strings (empty if no issues found).
+    Intended to be called from the application lifespan, after
+    logging is configured.
+    """
+    warnings: list[str] = []
+    secrets_dir = os.getenv("SECRETS_DIR", "").strip()
+    if not secrets_dir:
+        return warnings
+
+    secrets_path = Path(secrets_dir)
+    if not secrets_path.is_dir():
+        warnings.append(
+            f"SECRETS_DIR '{secrets_dir}' does not exist or is "
+            f"not a directory. File-based secrets will not be "
+            f"loaded."
+        )
+    elif os.access(secrets_path, os.W_OK):
+        warnings.append(
+            f"SECRETS_DIR '{secrets_dir}' is writable by the "
+            f"current process. For best security, this "
+            f"directory should be read-only."
+        )
+    return warnings
+
+
 @lru_cache
 def get_settings() -> Settings:
     """Return the current settings."""
-    secrets_dir = os.getenv("SECRETS_DIR")
+    secrets_dir = os.getenv("SECRETS_DIR", "").strip()
     settings_factory = cast("Callable[..., Settings]", Settings)
-    if secrets_dir and secrets_dir.strip():
+    if secrets_dir and Path(secrets_dir).is_dir():
         return settings_factory(_secrets_dir=secrets_dir)
     return settings_factory()

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from functools import lru_cache
 from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING, cast
 from urllib.parse import quote
 
 from cryptography.fernet import Fernet
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.config.helpers import get_project_root
 from app.logs import logger
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
 
 try:
     from .metadata import custom_metadata
@@ -27,6 +32,13 @@ except ModuleNotFoundError:  # pragma: no cover
 MIN_SECRET_KEY_LENGTH = 32
 
 
+def unwrap_secret(value: SecretStr | str) -> str:
+    """Return the raw value from either a SecretStr or plain string."""
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return value
+
+
 class Settings(BaseSettings):
     """Main Settings class.
 
@@ -34,11 +46,12 @@ class Settings(BaseSettings):
     file if it exists.
 
     SECURITY WARNING: Critical settings (SECRET_KEY, DB_PASSWORD, DB_USER)
-    MUST be set in your .env file. The application will fail to start if
-    these are not properly configured with secure values.
+    MUST be configured via environment variables, a .env file, or an optional
+    secrets directory. The application will fail to start if these are not
+    properly configured with secure values.
 
-    Do NOT put real passwords in this file - use the .env file instead
-    (it's in .gitignore and won't be stored in Git).
+    Do NOT put real passwords in this file. For local development, use the
+    .env file instead (it's in .gitignore and won't be stored in Git).
 
     To get started, copy .env.example to .env and update the values.
     """
@@ -58,7 +71,7 @@ class Settings(BaseSettings):
     # Setup the Postgresql database.
     # IMPORTANT: Set DB_USER and DB_PASSWORD in your .env file!
     db_user: str = "CHANGE_ME_IN_ENV_FILE"
-    db_password: str = "CHANGE_ME_IN_ENV_FILE"  # noqa: S105
+    db_password: SecretStr = SecretStr("CHANGE_ME_IN_ENV_FILE")
     db_address: str = "localhost"
     db_port: str = "5432"
     db_name: str = "api-template"
@@ -68,7 +81,7 @@ class Settings(BaseSettings):
     # Setup the TEST Postgresql database.
     # Note: Safe defaults for local/CI testing only
     test_db_user: str = "test_user"
-    test_db_password: str = "test_password_local_only"  # noqa: S105
+    test_db_password: SecretStr = SecretStr("test_password_local_only")
     test_db_address: str = "localhost"
     test_db_port: str = "5432"
     test_db_name: str = "api-template-test"
@@ -77,7 +90,7 @@ class Settings(BaseSettings):
     # Generate with: openssl rand -hex 32
     # Or Python: import secrets; secrets.token_hex(32)
     # Set SECRET_KEY in your .env file!
-    secret_key: str = "CHANGE_ME_IN_ENV_FILE"  # noqa: S105
+    secret_key: SecretStr = SecretStr("CHANGE_ME_IN_ENV_FILE")
     access_token_expire_minutes: int = 120
 
     # Custom Metadata
@@ -92,7 +105,7 @@ class Settings(BaseSettings):
     # Note: Set these in .env for production email functionality
     # Email features will fail gracefully if not configured
     mail_username: str = ""
-    mail_password: str = ""
+    mail_password: SecretStr = SecretStr("")
     mail_from: str = ""
     mail_port: int = 587
     mail_server: str = "mail.server.com"
@@ -106,8 +119,8 @@ class Settings(BaseSettings):
     admin_pages_enabled: bool = False
     admin_pages_route: str = "/admin"
     admin_pages_title: str = "API Administration"
-    admin_pages_encryption_key: str = Field(
-        default_factory=lambda: Fernet.generate_key().decode(),
+    admin_pages_encryption_key: SecretStr = Field(
+        default_factory=lambda: SecretStr(Fernet.generate_key().decode()),
         description="Encryption key for admin session tokens",
     )
     admin_pages_timeout: int = 86400
@@ -134,7 +147,7 @@ class Settings(BaseSettings):
     redis_enabled: bool = False
     redis_host: str = "localhost"
     redis_port: int = 6379
-    redis_password: str = ""
+    redis_password: SecretStr = SecretStr("")
     redis_db: int = 0
     cache_default_ttl: int = 300  # 5 minutes
 
@@ -157,8 +170,9 @@ class Settings(BaseSettings):
         Note:
             Password is URL-encoded to handle special characters safely.
         """
-        if self.redis_password:
-            encoded_password = quote(self.redis_password, safe="")
+        redis_password = unwrap_secret(self.redis_password)
+        if redis_password:
+            encoded_password = quote(redis_password, safe="")
             return (
                 f"redis://:{encoded_password}@"
                 f"{self.redis_host}:{self.redis_port}/{self.redis_db}"
@@ -190,8 +204,9 @@ class Settings(BaseSettings):
 
     @field_validator("secret_key")
     @classmethod
-    def validate_secret_key(cls: type[Settings], value: str) -> str:
+    def validate_secret_key(cls: type[Settings], value: SecretStr) -> SecretStr:
         """Ensure secret key is not a weak or default value."""
+        raw_value = unwrap_secret(value)
         weak_keys = [
             "CHANGE_ME_IN_ENV_FILE",
             "32DigitsofSecretNumbers",
@@ -199,7 +214,7 @@ class Settings(BaseSettings):
             "secret",
             "secretkey",
         ]
-        if value.lower() in [k.lower() for k in weak_keys]:
+        if raw_value.lower() in [k.lower() for k in weak_keys]:
             msg = (
                 "\n"
                 "=" * 70 + "\n"
@@ -208,23 +223,28 @@ class Settings(BaseSettings):
                 "Generate a strong key with one of these commands:\n"
                 "  openssl rand -hex 32\n"
                 "  python -c 'import secrets; print(secrets.token_hex(32))'\n\n"
-                "Then add it to your .env file:\n"
+                "Then configure it via environment, .env, or secrets dir:\n"
                 "  SECRET_KEY=your_generated_key_here\n"
                 "=" * 70
             )
             raise ValueError(msg)
-        if len(value) < MIN_SECRET_KEY_LENGTH:
+        if len(raw_value) < MIN_SECRET_KEY_LENGTH:
             msg = (
                 f"SECRET_KEY must be at least {MIN_SECRET_KEY_LENGTH} "
-                f"characters for security. Current length: {len(value)}"
+                f"characters for security. Current length: {len(raw_value)}"
             )
             raise ValueError(msg)
         return value
 
-    @field_validator("db_password")
+    @field_validator("db_password", "test_db_password")
     @classmethod
-    def validate_db_password(cls: type[Settings], value: str) -> str:
+    def validate_db_password(
+        cls: type[Settings],
+        value: SecretStr,
+        info: ValidationInfo,
+    ) -> SecretStr:
         """Ensure database password is not a weak or default value."""
+        raw_value = unwrap_secret(value)
         weak_passwords = [
             "CHANGE_ME_IN_ENV_FILE",
             "Sup3rS3cr3tP455w0rd",
@@ -232,14 +252,16 @@ class Settings(BaseSettings):
             "password",
             "admin",
         ]
-        if value in weak_passwords:
+        if raw_value in weak_passwords:
+            field_name = (info.field_name or "db_password").upper()
             msg = (
                 "\n"
                 "=" * 70 + "\n"
-                "SECURITY ERROR: DB_PASSWORD is using a weak/default value!\n"
+                f"SECURITY ERROR: {field_name} is using a weak/default value!\n"
                 "=" * 70 + "\n"
-                "Set a strong database password in your .env file:\n"
-                "  DB_PASSWORD=your_secure_password_here\n"
+                "Set a strong database password via environment, .env, "
+                "or secrets dir:\n"
+                f"  {field_name}=your_secure_password_here\n"
                 "=" * 70
             )
             raise ValueError(msg)
@@ -255,7 +277,8 @@ class Settings(BaseSettings):
                 "=" * 70 + "\n"
                 "CONFIGURATION ERROR: DB_USER is not set!\n"
                 "=" * 70 + "\n"
-                "Set your database username in your .env file:\n"
+                "Set your database username via environment, .env, "
+                "or secrets dir:\n"
                 "  DB_USER=your_database_username\n"
                 "=" * 70
             )
@@ -266,4 +289,8 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     """Return the current settings."""
-    return Settings()
+    secrets_dir = os.getenv("SECRETS_DIR")
+    settings_factory = cast("Callable[..., Settings]", Settings)
+    if secrets_dir and secrets_dir.strip():
+        return settings_factory(_secrets_dir=secrets_dir)
+    return settings_factory()

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -315,15 +315,13 @@ def check_secrets_dir() -> list[str]:
     secrets_path = Path(secrets_dir)
     if not secrets_path.is_dir():
         warnings.append(
-            f"SECRETS_DIR '{secrets_dir}' does not exist or is "
-            f"not a directory. File-based secrets will not be "
-            f"loaded."
+            "SECRETS_DIR is set but does not exist or is not a "
+            "directory. File-based secrets will not be loaded."
         )
     elif os.access(secrets_path, os.W_OK):
         warnings.append(
-            f"SECRETS_DIR '{secrets_dir}' is writable by the "
-            f"current process. For best security, this "
-            f"directory should be read-only."
+            "SECRETS_DIR is writable by the current process. "
+            "For best security, this directory should be read-only."
         )
     return warnings
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -259,6 +259,19 @@ class Settings(BaseSettings):
     ) -> SecretStr:
         """Ensure database password is not a weak or default value."""
         raw_value = unwrap_secret(value)
+        field_name = (info.field_name or "db_password").upper()
+        if not raw_value.strip():
+            msg = (
+                "\n"
+                "=" * 70 + "\n"
+                f"SECURITY ERROR: {field_name} must not be empty!\n"
+                "=" * 70 + "\n"
+                "Set a strong database password via environment, .env, "
+                "or secrets dir:\n"
+                f"  {field_name}=your_secure_password_here\n"
+                "=" * 70
+            )
+            raise ValueError(msg)
         weak_passwords = [
             "CHANGE_ME_IN_ENV_FILE",
             "Sup3rS3cr3tP455w0rd",
@@ -267,7 +280,6 @@ class Settings(BaseSettings):
             "admin",
         ]
         if raw_value in weak_passwords:
-            field_name = (info.field_name or "db_password").upper()
             msg = (
                 "\n"
                 "=" * 70 + "\n"

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -3,6 +3,7 @@
 import os
 from collections.abc import AsyncGenerator
 from typing import Any
+from urllib.parse import quote
 
 from sqlalchemy import MetaData
 from sqlalchemy.ext.asyncio import (
@@ -32,7 +33,8 @@ def get_database_url(*, use_test_db: bool = False) -> str:
 
     return (
         "postgresql+asyncpg://"
-        f"{settings.db_user}:{unwrap_secret(settings.db_password)}@"
+        f"{settings.db_user}:"
+        f"{quote(unwrap_secret(settings.db_password), safe='')}@"
         f"{settings.db_address}:{settings.db_port}/"
         f"{db_name}"
     )

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import DeclarativeBase
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 
 
 def get_database_url(*, use_test_db: bool = False) -> str:
@@ -32,7 +32,7 @@ def get_database_url(*, use_test_db: bool = False) -> str:
 
     return (
         "postgresql+asyncpg://"
-        f"{settings.db_user}:{settings.db_password}@"
+        f"{settings.db_user}:{unwrap_secret(settings.db_password)}@"
         f"{settings.db_address}:{settings.db_port}/"
         f"{db_name}"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from app.admin import register_admin
 from app.config.helpers import get_api_version, get_project_root
 from app.config.log_config import get_log_config
 from app.config.openapi import custom_openapi
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import async_session
 from app.metrics.instrumentator import register_metrics
 from app.middleware.cache_logging import CacheLoggingMiddleware
@@ -100,7 +100,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, None]:
     if get_settings().cache_enabled:
         if get_settings().redis_enabled:
             # Warn about missing authentication
-            if not get_settings().redis_password:
+            if not unwrap_secret(get_settings().redis_password):
                 warning_msg = (
                     "Redis is enabled without authentication "
                     "(REDIS_PASSWORD is empty). Ensure Redis is secured "

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from app.admin import register_admin
 from app.config.helpers import get_api_version, get_project_root
 from app.config.log_config import get_log_config
 from app.config.openapi import custom_openapi
-from app.config.settings import get_settings, unwrap_secret
+from app.config.settings import check_secrets_dir, get_settings, unwrap_secret
 from app.database.db import async_session
 from app.metrics.instrumentator import register_metrics
 from app.middleware.cache_logging import CacheLoggingMiddleware
@@ -72,6 +72,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, None]:
     """
     # Initialize loguru logging within the server process.
     get_log_config()
+
+    # Validate SECRETS_DIR configuration if set.
+    for warning_msg in check_secrets_dir():
+        logger.warning(warning_msg)
+        loguru_logger.warning(warning_msg)
 
     if "*" in cors_list:
         warning_msg = (

--- a/app/managers/api_key.py
+++ b/app/managers/api_key.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import get_database
 from app.database.helpers import (
     add_new_api_key_,
@@ -50,7 +50,7 @@ class ApiKeyManager:
         them is computationally infeasible. HMAC also prevents
         length-extension attacks possible with raw SHA256 hashing.
         """
-        secret_key = get_settings().secret_key.encode()
+        secret_key = unwrap_secret(get_settings().secret_key).encode()
         return hmac.new(secret_key, key.encode(), hashlib.sha256).hexdigest()
 
     @classmethod

--- a/app/managers/auth.py
+++ b/app/managers/auth.py
@@ -10,7 +10,7 @@ from pydantic import NameEmail
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import get_database
 from app.database.helpers import (
     get_user_by_email_,
@@ -66,7 +66,9 @@ class AuthManager:
                 ),
             }
             token = jwt.encode(
-                payload, get_settings().secret_key, algorithm="HS256"
+                payload,
+                unwrap_secret(get_settings().secret_key),
+                algorithm="HS256",
             )
         except (jwt.PyJWTError, AttributeError) as exc:
             user_id = getattr(user, "id", "unknown")
@@ -94,7 +96,9 @@ class AuthManager:
                 "typ": "refresh",
             }
             token = jwt.encode(
-                payload, get_settings().secret_key, algorithm="HS256"
+                payload,
+                unwrap_secret(get_settings().secret_key),
+                algorithm="HS256",
             )
         except (jwt.PyJWTError, AttributeError) as exc:
             user_id = getattr(user, "id", "unknown")
@@ -123,7 +127,9 @@ class AuthManager:
                 "typ": "verify",
             }
             token = jwt.encode(
-                payload, get_settings().secret_key, algorithm="HS256"
+                payload,
+                unwrap_secret(get_settings().secret_key),
+                algorithm="HS256",
             )
         except (jwt.PyJWTError, AttributeError) as exc:
             user_id = getattr(user, "id", "unknown")
@@ -154,7 +160,9 @@ class AuthManager:
                 "typ": "reset",
             }
             token = jwt.encode(
-                payload, get_settings().secret_key, algorithm="HS256"
+                payload,
+                unwrap_secret(get_settings().secret_key),
+                algorithm="HS256",
             )
         except (jwt.PyJWTError, AttributeError) as exc:
             user_id = getattr(user, "id", "unknown")
@@ -196,7 +204,7 @@ class AuthManager:
         try:
             payload = jwt.decode(
                 refresh_token.refresh,
-                get_settings().secret_key,
+                unwrap_secret(get_settings().secret_key),
                 algorithms=["HS256"],
                 options={"verify_sub": False},
             )
@@ -300,7 +308,7 @@ class AuthManager:
         try:
             payload = jwt.decode(
                 code,
-                get_settings().secret_key,
+                unwrap_secret(get_settings().secret_key),
                 algorithms=["HS256"],
                 options={"verify_sub": False},
             )
@@ -474,7 +482,7 @@ class AuthManager:
         try:
             payload = jwt.decode(
                 code,
-                get_settings().secret_key,
+                unwrap_secret(get_settings().secret_key),
                 algorithms=["HS256"],
                 options={"verify_sub": False},
             )
@@ -658,7 +666,7 @@ async def get_jwt_user(  # noqa: C901
         # Decode and validate the token
         payload = jwt.decode(
             credentials.credentials,
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithms=["HS256"],
             options={"verify_sub": False},
         )

--- a/app/managers/email.py
+++ b/app/managers/email.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from fastapi import BackgroundTasks  # noqa: TC002
 from fastapi.responses import JSONResponse
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
-from pydantic import SecretStr
 
 from app.config.settings import get_settings
 from app.logs import LogCategory, category_logger
@@ -27,7 +26,7 @@ class EmailManager:
         """
         self.conf = ConnectionConfig(
             MAIL_USERNAME=get_settings().mail_username,
-            MAIL_PASSWORD=SecretStr(get_settings().mail_password),
+            MAIL_PASSWORD=get_settings().mail_password,
             MAIL_FROM=get_settings().mail_from,
             MAIL_PORT=get_settings().mail_port,
             MAIL_SERVER=get_settings().mail_server,

--- a/app/resources/auth.py
+++ b/app/resources/auth.py
@@ -20,7 +20,7 @@ from starlette.templating import _TemplateResponse
 
 from app.cache import invalidate_users_list_cache
 from app.config.helpers import get_project_root
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.db import get_database
 from app.managers.auth import AuthManager, ResponseMessages
 from app.managers.helpers import (
@@ -216,7 +216,7 @@ async def reset_password_form(
         try:
             payload = jwt.decode(
                 code,
-                get_settings().secret_key,
+                unwrap_secret(get_settings().secret_key),
                 algorithms=["HS256"],
                 options={"verify_sub": False},
             )

--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -102,9 +102,10 @@ using Uvicorn, Gunicorn and Containers.
 
 !!! info "Environment Setup"
     Whichever method you choose, you still need to set up a virtual environment,
-    install all the dependencies, setup your `.env` file (or use Environment
-    variables if your hosting provider uses these - for example Railway or Heroku)
-    and set up and migrate your Database.
+    install all the dependencies, and configure your settings. In production,
+    prefer environment variables. A `.env` file is mainly for local development,
+    and `SECRETS_DIR` is available as an optional file-secret fallback. You
+    still need to set up and migrate your Database.
 
 ## Database Migration Strategy
 

--- a/docs/usage/configuration/environment.md
+++ b/docs/usage/configuration/environment.md
@@ -17,13 +17,24 @@ Configuration precedence is:
 2. `.env`
 3. `SECRETS_DIR`
 
-If `SECRETS_DIR` is set, each file in that directory should be named after the
-setting, and the file contents should be the value. For example:
+If `SECRETS_DIR` is set, it should point to a directory containing one file per
+secret. Each filename should match a setting name, and the file contents should
+be the value. This is useful for production deployments where you prefer
+OS-managed secret files instead of storing sensitive values in a `.env` file.
+Common locations include `/etc/myapp/secrets` on Linux servers,
+`/run/secrets` in containers, `./secrets` for local testing, or a custom path
+on Windows. For example:
 
 ```text
 /run/secrets/DB_PASSWORD
 /run/secrets/SECRET_KEY
 ```
+
+The directory should be readable only by the account running the application
+and protected with appropriate filesystem permissions. This improves separation
+of secrets from source code and deployment files, but it does not replace
+proper host security: an attacker with full system access may still be able to
+obtain them.
 
 !!! info
     The Database (and test database if you are running the tests) and User must

--- a/docs/usage/configuration/environment.md
+++ b/docs/usage/configuration/environment.md
@@ -6,6 +6,25 @@ Database (and other) settings can be read from environment variables or from a
 `.env` file in the project root. See the `.env.example` file for how to use, in
 fact you can just copy this file to `.env` and edit the settings as required.
 
+For local development, `.env` is the normal workflow. For production,
+environment variables are preferred. You can also optionally set
+`SECRETS_DIR` to a directory of files so settings can fall back to file-based
+secrets when they are not present in the environment or `.env`.
+
+Configuration precedence is:
+
+1. Environment variables
+2. `.env`
+3. `SECRETS_DIR`
+
+If `SECRETS_DIR` is set, each file in that directory should be named after the
+setting, and the file contents should be the value. For example:
+
+```text
+/run/secrets/DB_PASSWORD
+/run/secrets/SECRET_KEY
+```
+
 !!! info
     The Database (and test database if you are running the tests) and User must
     already exist in your Postgres system!

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@
 
 import jwt
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 
 
 def get_token(sub: int, exp: float, typ: str) -> str:
@@ -13,6 +13,6 @@ def get_token(sub: int, exp: float, typ: str) -> str:
             "exp": exp,
             "typ": typ,
         },
-        get_settings().secret_key,
+        unwrap_secret(get_settings().secret_key),
         algorithm="HS256",
     )

--- a/tests/integration/test_protected_user_routes.py
+++ b/tests/integration/test_protected_user_routes.py
@@ -6,7 +6,7 @@ import jwt
 import pytest
 from fastapi import status
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.helpers import hash_password
 from app.managers.auth import AuthManager
 from app.models.user import User
@@ -112,7 +112,7 @@ class TestProtectedUserRoutes:
                 "exp": datetime.datetime.now(tz=datetime.timezone.utc)
                 + datetime.timedelta(minutes=10),
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
 

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException, status
 from pydantic import ValidationError
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.database.helpers import verify_password
 from app.managers.auth import AuthManager, ResponseMessages
 from app.managers.helpers import BCRYPT_PASSWORD_MAX_BYTES, MAX_JWT_TOKEN_LENGTH
@@ -38,7 +38,7 @@ class TestAuthManager:
 
         payload = jwt.decode(
             token,
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithms=["HS256"],
             options={"verify_sub": False},
         )
@@ -64,7 +64,7 @@ class TestAuthManager:
 
         payload = jwt.decode(
             refresh_token,
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithms=["HS256"],
             options={"verify_sub": False},
         )
@@ -91,7 +91,7 @@ class TestAuthManager:
 
         payload = jwt.decode(
             verify_token,
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithms=["HS256"],
             options={"verify_sub": False},
         )
@@ -118,7 +118,7 @@ class TestAuthManager:
 
         payload = jwt.decode(
             reset_token,
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithms=["HS256"],
             options={"verify_sub": False},
         )
@@ -725,7 +725,7 @@ class TestAuthManager:
                 "typ": "refresh",
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 3600,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         with pytest.raises(HTTPException) as exc_info:
@@ -744,7 +744,7 @@ class TestAuthManager:
                 "typ": "verify",
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 600,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         with pytest.raises(HTTPException) as exc_info:
@@ -761,7 +761,7 @@ class TestAuthManager:
                 "typ": "reset",
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 1800,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         with pytest.raises(HTTPException) as exc_info:
@@ -782,7 +782,7 @@ class TestAuthManager:
                 "sub": "1",  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 3600,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         # Should succeed because we convert "1" to 1
@@ -806,7 +806,7 @@ class TestAuthManager:
                 "sub": "1",  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 600,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         # Should succeed because we convert "1" to 1
@@ -830,7 +830,7 @@ class TestAuthManager:
                 "sub": "1",  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 1800,
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         new_password = "newpassword123!"  # noqa: S105

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -221,7 +221,7 @@ class TestDatabase:
         mock_settings = mocker.patch("app.database.db.get_settings")
         mock_settings.return_value = Settings(
             db_user="test_user",
-            db_password=SecretStr("test_password"),
+            db_password=SecretStr("p@ss:word/with#chars"),
             db_address="test_host",
             db_port="5432",
             db_name="test_db",
@@ -231,14 +231,14 @@ class TestDatabase:
         # Test normal database URL
         url = db.get_database_url()
         assert url == (
-            "postgresql+asyncpg://test_user:test_password"
+            "postgresql+asyncpg://test_user:p%40ss%3Aword%2Fwith%23chars"
             "@test_host:5432/test_db"
         )
 
         # Test test database URL
         url = db.get_database_url(use_test_db=True)
         assert url == (
-            "postgresql+asyncpg://test_user:test_password"
+            "postgresql+asyncpg://test_user:p%40ss%3Aword%2Fwith%23chars"
             "@test_host:5432/test_db_test"
         )
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -242,6 +242,28 @@ class TestDatabase:
             "@test_host:5432/test_db_test"
         )
 
+    def test_get_database_url_encodes_password(
+        self, mocker, monkeypatch
+    ) -> None:
+        """Test database URL encodes reserved characters in password."""
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        mock_settings = mocker.patch("app.database.db.get_settings")
+        mock_settings.return_value = Settings(
+            db_user="test_user",
+            db_password=SecretStr("p@ss:w0rd/#%"),
+            db_address="test_host",
+            db_port="5432",
+            db_name="test_db",
+            test_db_name="test_db_test",
+        )
+
+        url = db.get_database_url()
+
+        assert url == (
+            "postgresql+asyncpg://test_user:p%40ss%3Aw0rd%2F%23%25"
+            "@test_host:5432/test_db"
+        )
+
     def test_get_database_url_github_actions(self, mocker) -> None:
         """Test get_database_url() returns the correct URL in GitHub Actions."""
         mocker.patch.dict(os.environ, {"GITHUB_ACTIONS": "true"})

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 
 import pytest
+from pydantic import SecretStr
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
@@ -220,7 +221,7 @@ class TestDatabase:
         mock_settings = mocker.patch("app.database.db.get_settings")
         mock_settings.return_value = Settings(
             db_user="test_user",
-            db_password="test_password",  # noqa: S106
+            db_password=SecretStr("test_password"),
             db_address="test_host",
             db_port="5432",
             db_name="test_db",

--- a/tests/unit/test_email_manager.py
+++ b/tests/unit/test_email_manager.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import status
 from pydantic import NameEmail
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.schemas.email import EmailSchema, EmailTemplateSchema
 
 
@@ -41,7 +41,7 @@ class TestEmailManager:
         """Test the EmailManager constructor."""
         assert get_settings().mail_username == email_manager.conf.MAIL_USERNAME
         assert (
-            get_settings().mail_password
+            unwrap_secret(get_settings().mail_password)
             == email_manager.conf.MAIL_PASSWORD.get_secret_value()
         )
         assert get_settings().mail_from == email_manager.conf.MAIL_FROM

--- a/tests/unit/test_jwt_auth.py
+++ b/tests/unit/test_jwt_auth.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 
-from app.config.settings import get_settings
+from app.config.settings import get_settings, unwrap_secret
 from app.managers.auth import ResponseMessages, get_jwt_user
 from app.managers.user import UserManager
 from app.models.user import User
@@ -89,7 +89,7 @@ class TestJWTAuth:
                 "exp": datetime.datetime.now(tz=datetime.timezone.utc)
                 + datetime.timedelta(minutes=10),
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         mock_req = mocker.patch(self.mock_request_path)
@@ -115,7 +115,7 @@ class TestJWTAuth:
                 "exp": datetime.datetime.now(tz=datetime.timezone.utc)
                 + datetime.timedelta(minutes=10),
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         mock_req = mocker.patch(self.mock_request_path)
@@ -143,7 +143,7 @@ class TestJWTAuth:
                 "exp": datetime.datetime.now(tz=datetime.timezone.utc)
                 + datetime.timedelta(minutes=10),
             },
-            get_settings().secret_key,
+            unwrap_secret(get_settings().secret_key),
             algorithm="HS256",
         )
         mock_req = mocker.patch(self.mock_request_path)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -310,12 +310,27 @@ class TestSettingsSources:
     """Test settings source precedence and secrets-dir support."""
 
     @staticmethod
+    def clear_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Clear ambient env vars that would override test-specific sources."""
+        for env_name in (
+            "DB_USER",
+            "DB_PASSWORD",
+            "TEST_DB_PASSWORD",
+            "SECRET_KEY",
+            "SECRETS_DIR",
+        ):
+            monkeypatch.delenv(env_name, raising=False)
+
+    @staticmethod
     def write_secret(secret_dir: Path, name: str, value: str) -> None:
         """Write one secret file using Pydantic's file-secret format."""
         (secret_dir / name).write_text(value, encoding="utf-8")
 
-    def test_settings_load_from_secrets_dir(self, tmp_path: Path) -> None:
+    def test_settings_load_from_secrets_dir(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
         """Settings should load required values from a secrets directory."""
+        self.clear_settings_env(monkeypatch)
         self.write_secret(tmp_path, "DB_USER", "secret_user")
         self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
         self.write_secret(tmp_path, "TEST_DB_PASSWORD", "TestSecretsPass123!")
@@ -334,8 +349,11 @@ class TestSettingsSources:
         assert unwrap_secret(settings.db_password) == "SecretsPassword123!"
         assert unwrap_secret(settings.test_db_password) == "TestSecretsPass123!"
 
-    def test_dotenv_overrides_secrets_dir(self, tmp_path: Path) -> None:
+    def test_dotenv_overrides_secrets_dir(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
         """Dotenv values should override secret-file values."""
+        self.clear_settings_env(monkeypatch)
         secrets_dir = tmp_path / "secrets"
         secrets_dir.mkdir()
         env_file = tmp_path / ".env"
@@ -417,9 +435,10 @@ class TestSettingsSources:
         get_settings.cache_clear()
 
     def test_weak_secret_key_from_secrets_dir_rejected(
-        self, tmp_path: Path
+        self, monkeypatch, tmp_path: Path
     ) -> None:
         """Weak secret keys from file secrets should still be rejected."""
+        self.clear_settings_env(monkeypatch)
         self.write_secret(tmp_path, "DB_USER", "secret_user")
         self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
         self.write_secret(tmp_path, "SECRET_KEY", "secret")
@@ -431,9 +450,10 @@ class TestSettingsSources:
             build_settings(_env_file=None, _secrets_dir=tmp_path)
 
     def test_weak_test_db_password_from_secrets_dir_rejected(
-        self, tmp_path: Path
+        self, monkeypatch, tmp_path: Path
     ) -> None:
         """Weak TEST_DB_PASSWORD values from file secrets should be rejected."""
+        self.clear_settings_env(monkeypatch)
         self.write_secret(tmp_path, "DB_USER", "secret_user")
         self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
         self.write_secret(

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -170,6 +170,43 @@ class TestDbPasswordValidator:
         ):
             Settings()
 
+    def test_empty_db_password_rejected(self, monkeypatch) -> None:
+        """Test that an empty DB_PASSWORD is rejected."""
+        monkeypatch.setenv("DB_USER", "testuser")
+        monkeypatch.setenv("SECRET_KEY", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6")
+        monkeypatch.setenv("DB_PASSWORD", "")
+
+        with pytest.raises(
+            ValueError,
+            match=r"SECURITY ERROR: DB_PASSWORD must not be empty!",
+        ):
+            Settings()
+
+    def test_whitespace_db_password_rejected(self, monkeypatch) -> None:
+        """Test that a whitespace-only DB_PASSWORD is rejected."""
+        monkeypatch.setenv("DB_USER", "testuser")
+        monkeypatch.setenv("SECRET_KEY", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6")
+        monkeypatch.setenv("DB_PASSWORD", "   ")
+
+        with pytest.raises(
+            ValueError,
+            match=r"SECURITY ERROR: DB_PASSWORD must not be empty!",
+        ):
+            Settings()
+
+    def test_empty_test_db_password_rejected(self, monkeypatch) -> None:
+        """Test that an empty TEST_DB_PASSWORD is rejected."""
+        monkeypatch.setenv("DB_USER", "testuser")
+        monkeypatch.setenv("SECRET_KEY", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6")
+        monkeypatch.setenv("DB_PASSWORD", "ValidPassword123!")
+        monkeypatch.setenv("TEST_DB_PASSWORD", "")
+
+        with pytest.raises(
+            ValueError,
+            match=(r"SECURITY ERROR: TEST_DB_PASSWORD must not be empty!"),
+        ):
+            Settings()
+
 
 class TestDbUserValidator:
     """Test the DB_USER validator."""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -4,9 +4,22 @@ This includes tests for field validators like api_root trimming and security
 validators that catch weak or default credential values.
 """
 
-import pytest
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
-from app.config.settings import Settings
+import pytest
+from pydantic import SecretStr
+
+from app.config.settings import Settings, get_settings, unwrap_secret
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
+
+def build_settings(**kwargs: object) -> Settings:
+    """Create Settings with runtime-only pydantic-settings kwargs."""
+    settings_factory = cast("Callable[..., Settings]", Settings)
+    return settings_factory(**kwargs)
 
 
 class TestApiRootValidator:
@@ -88,7 +101,11 @@ class TestSecretKeyValidator:
 
         # Should not raise
         settings = Settings()
-        assert settings.secret_key == "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"  # noqa: S105
+        assert isinstance(settings.secret_key, SecretStr)
+        assert (
+            unwrap_secret(settings.secret_key)
+            == "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+        )
 
 
 class TestDbPasswordValidator:
@@ -128,7 +145,24 @@ class TestDbPasswordValidator:
 
         # Should not raise
         settings = Settings()
-        assert settings.db_password == "MySecureDbPassword123!"  # noqa: S105
+        assert isinstance(settings.db_password, SecretStr)
+        assert unwrap_secret(settings.db_password) == "MySecureDbPassword123!"
+
+    def test_weak_test_db_password_rejected(self, monkeypatch) -> None:
+        """Test that weak test database passwords are rejected."""
+        monkeypatch.setenv("DB_USER", "testuser")
+        monkeypatch.setenv("SECRET_KEY", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6")
+        monkeypatch.setenv("DB_PASSWORD", "ValidPassword123!")
+        monkeypatch.setenv("TEST_DB_PASSWORD", "admin")
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"SECURITY ERROR: TEST_DB_PASSWORD is using a "
+                r"weak/default value!"
+            ),
+        ):
+            Settings()
 
 
 class TestDbUserValidator:
@@ -174,10 +208,13 @@ class TestValidatorsIntegration:
         # Should not raise
         settings = Settings()
         assert settings.db_user == "production_user"
-        assert settings.db_password == "SecureProductionPassword123!"  # noqa: S105
         assert (
-            settings.secret_key
-            == "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4"  # noqa: S105
+            unwrap_secret(settings.db_password)
+            == "SecureProductionPassword123!"
+        )
+        assert (
+            unwrap_secret(settings.secret_key)
+            == "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4"
         )
 
     def test_multiple_invalid_settings_first_error_raised(
@@ -267,3 +304,150 @@ class TestRedisUrlProperty:
         assert "@localhost:6379/0" in redis_url, (
             "Redis URL should contain host and port"
         )
+
+
+class TestSettingsSources:
+    """Test settings source precedence and secrets-dir support."""
+
+    @staticmethod
+    def write_secret(secret_dir: Path, name: str, value: str) -> None:
+        """Write one secret file using Pydantic's file-secret format."""
+        (secret_dir / name).write_text(value, encoding="utf-8")
+
+    def test_settings_load_from_secrets_dir(self, tmp_path: Path) -> None:
+        """Settings should load required values from a secrets directory."""
+        self.write_secret(tmp_path, "DB_USER", "secret_user")
+        self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
+        self.write_secret(tmp_path, "TEST_DB_PASSWORD", "TestSecretsPass123!")
+        self.write_secret(
+            tmp_path,
+            "SECRET_KEY",
+            "abcd1234abcd1234abcd1234abcd1234",
+        )
+
+        settings = build_settings(_env_file=None, _secrets_dir=tmp_path)
+
+        assert settings.db_user == "secret_user"
+        assert isinstance(settings.secret_key, SecretStr)
+        assert isinstance(settings.db_password, SecretStr)
+        assert isinstance(settings.test_db_password, SecretStr)
+        assert unwrap_secret(settings.db_password) == "SecretsPassword123!"
+        assert unwrap_secret(settings.test_db_password) == "TestSecretsPass123!"
+
+    def test_dotenv_overrides_secrets_dir(self, tmp_path: Path) -> None:
+        """Dotenv values should override secret-file values."""
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        env_file = tmp_path / ".env"
+
+        self.write_secret(secrets_dir, "DB_USER", "secret_user")
+        self.write_secret(secrets_dir, "DB_PASSWORD", "SecretsPassword123!")
+        self.write_secret(
+            secrets_dir,
+            "SECRET_KEY",
+            "abcd1234abcd1234abcd1234abcd1234",
+        )
+        env_file.write_text(
+            (
+                "DB_USER=dotenv_user\n"
+                "DB_PASSWORD=DotenvPassword123!\n"
+                "SECRET_KEY=1234abcd1234abcd1234abcd1234abcd"
+            ),
+            encoding="utf-8",
+        )
+
+        settings = build_settings(_env_file=env_file, _secrets_dir=secrets_dir)
+
+        assert settings.db_user == "dotenv_user"
+        assert unwrap_secret(settings.db_password) == "DotenvPassword123!"
+        assert (
+            unwrap_secret(settings.secret_key)
+            == "1234abcd1234abcd1234abcd1234abcd"
+        )
+
+    def test_environment_overrides_dotenv_and_secrets(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Environment variables should have highest precedence."""
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        env_file = tmp_path / ".env"
+
+        self.write_secret(secrets_dir, "DB_USER", "secret_user")
+        self.write_secret(secrets_dir, "DB_PASSWORD", "SecretsPassword123!")
+        self.write_secret(
+            secrets_dir,
+            "SECRET_KEY",
+            "abcd1234abcd1234abcd1234abcd1234",
+        )
+        env_file.write_text(
+            (
+                "DB_USER=dotenv_user\n"
+                "DB_PASSWORD=DotenvPassword123!\n"
+                "SECRET_KEY=1234abcd1234abcd1234abcd1234abcd"
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("DB_USER", "env_user")
+        monkeypatch.setenv("DB_PASSWORD", "EnvPassword123!")
+        monkeypatch.setenv("SECRET_KEY", "feedfacefeedfacefeedfacefeedface")
+
+        settings = build_settings(_env_file=env_file, _secrets_dir=secrets_dir)
+
+        assert settings.db_user == "env_user"
+        assert unwrap_secret(settings.db_password) == "EnvPassword123!"
+        assert (
+            unwrap_secret(settings.secret_key)
+            == "feedfacefeedfacefeedfacefeedface"
+        )
+
+    def test_get_settings_uses_secrets_dir_env_var(
+        self, monkeypatch, mocker
+    ) -> None:
+        """get_settings should pass SECRETS_DIR through to Settings."""
+        mock_settings = mocker.patch("app.config.settings.Settings")
+        secrets_dir = "/var/run/app-secrets"
+        monkeypatch.setenv("SECRETS_DIR", secrets_dir)
+        get_settings.cache_clear()
+
+        settings = get_settings()
+
+        mock_settings.assert_called_once_with(_secrets_dir=secrets_dir)
+        assert settings is mock_settings.return_value
+        get_settings.cache_clear()
+
+    def test_weak_secret_key_from_secrets_dir_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """Weak secret keys from file secrets should still be rejected."""
+        self.write_secret(tmp_path, "DB_USER", "secret_user")
+        self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
+        self.write_secret(tmp_path, "SECRET_KEY", "secret")
+
+        with pytest.raises(
+            ValueError,
+            match=r"SECURITY ERROR: SECRET_KEY is using a weak/default value!",
+        ):
+            build_settings(_env_file=None, _secrets_dir=tmp_path)
+
+    def test_weak_test_db_password_from_secrets_dir_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """Weak TEST_DB_PASSWORD values from file secrets should be rejected."""
+        self.write_secret(tmp_path, "DB_USER", "secret_user")
+        self.write_secret(tmp_path, "DB_PASSWORD", "SecretsPassword123!")
+        self.write_secret(
+            tmp_path,
+            "SECRET_KEY",
+            "abcd1234abcd1234abcd1234abcd1234",
+        )
+        self.write_secret(tmp_path, "TEST_DB_PASSWORD", "admin")
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"SECURITY ERROR: TEST_DB_PASSWORD is using a "
+                r"weak/default value!"
+            ),
+        ):
+            build_settings(_env_file=None, _secrets_dir=tmp_path)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -389,6 +389,7 @@ class TestSettingsSources:
         self, monkeypatch, tmp_path: Path
     ) -> None:
         """Environment variables should have highest precedence."""
+        self.clear_settings_env(monkeypatch)
         secrets_dir = tmp_path / "secrets"
         secrets_dir.mkdir()
         env_file = tmp_path / ".env"

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from cryptography.fernet import Fernet
 from pydantic import SecretStr
 
 from app.config.settings import Settings, get_settings, unwrap_secret
@@ -317,6 +318,7 @@ class TestSettingsSources:
             "DB_PASSWORD",
             "TEST_DB_PASSWORD",
             "SECRET_KEY",
+            "ADMIN_PAGES_ENCRYPTION_KEY",
             "SECRETS_DIR",
         ):
             monkeypatch.delenv(env_name, raising=False)
@@ -418,6 +420,23 @@ class TestSettingsSources:
             unwrap_secret(settings.secret_key)
             == "feedfacefeedfacefeedfacefeedface"
         )
+
+    def test_empty_admin_encryption_key_generates_default(
+        self, monkeypatch
+    ) -> None:
+        """Empty admin encryption key env value should generate a key."""
+        self.clear_settings_env(monkeypatch)
+        monkeypatch.setenv("DB_USER", "env_user")
+        monkeypatch.setenv("DB_PASSWORD", "EnvPassword123!")
+        monkeypatch.setenv("SECRET_KEY", "feedfacefeedfacefeedfacefeedface")
+        monkeypatch.setenv("ADMIN_PAGES_ENCRYPTION_KEY", "")
+
+        settings = Settings()
+        encryption_key = unwrap_secret(settings.admin_pages_encryption_key)
+
+        assert isinstance(settings.admin_pages_encryption_key, SecretStr)
+        assert encryption_key
+        assert Fernet(encryption_key.encode())
 
     def test_get_settings_uses_secrets_dir_env_var(
         self, monkeypatch, mocker

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -11,7 +11,12 @@ import pytest
 from cryptography.fernet import Fernet
 from pydantic import SecretStr
 
-from app.config.settings import Settings, get_settings, unwrap_secret
+from app.config.settings import (
+    Settings,
+    check_secrets_dir,
+    get_settings,
+    unwrap_secret,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
@@ -446,6 +451,7 @@ class TestSettingsSources:
         mock_settings = mocker.patch("app.config.settings.Settings")
         secrets_dir = "/var/run/app-secrets"
         monkeypatch.setenv("SECRETS_DIR", secrets_dir)
+        mocker.patch("app.config.settings.Path.is_dir", return_value=True)
         get_settings.cache_clear()
 
         settings = get_settings()
@@ -491,3 +497,31 @@ class TestSettingsSources:
             ),
         ):
             build_settings(_env_file=None, _secrets_dir=tmp_path)
+
+    def test_secrets_dir_warns_when_not_found(self, monkeypatch) -> None:
+        """check_secrets_dir returns warning when path does not exist."""
+        monkeypatch.setenv("SECRETS_DIR", "/no/such/secrets/dir")
+
+        warnings = check_secrets_dir()
+
+        assert len(warnings) == 1
+        assert "does not exist" in warnings[0]
+
+    def test_secrets_dir_warns_when_writable(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """check_secrets_dir returns warning when dir is writable."""
+        monkeypatch.setenv("SECRETS_DIR", str(tmp_path))
+
+        warnings = check_secrets_dir()
+
+        assert len(warnings) == 1
+        assert "writable" in warnings[0]
+
+    def test_secrets_dir_no_warnings_when_unset(self, monkeypatch) -> None:
+        """check_secrets_dir returns empty list when SECRETS_DIR unset."""
+        monkeypatch.delenv("SECRETS_DIR", raising=False)
+
+        warnings = check_secrets_dir()
+
+        assert warnings == []


### PR DESCRIPTION
## Summary
- add optional `SECRETS_DIR` support to Pydantic settings with precedence `env vars -> .env -> secrets dir`
- convert sensitive settings to `SecretStr`, including `test_db_password`, and unwrap them only where raw values are required
- update configuration docs to explain `.env` for development, environment variables for production, and `SECRETS_DIR` as an optional file-secret fallback

This keeps existing configuration behaviour intact when `SECRETS_DIR` is not set, while allowing deployments to source secrets from OS-managed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional file-based secrets via SECRETS_DIR with clear precedence (env → .env → secrets dir).
  * Automatic generation/validation for admin/encryption keys and stronger secret types.

* **Bug Fixes**
  * Secret values are now unwrapped before use and passwords are URL-encoded where required.
  * Startup now emits warnings for misconfigured or unwritable secrets directory.

* **Documentation**
  * Deployment/config guidance updated to document SECRETS_DIR and preferred configuration order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->