### PR TITLE
test: return to 100% app coverage

### DIFF
--- a/tests/unit/test_lifespan.py
+++ b/tests/unit/test_lifespan.py
@@ -238,6 +238,36 @@ class TestLifespan:
         )
         loguru_warning.assert_called_once()
 
+    async def test_lifespan_warns_on_secrets_dir_issues(
+        self, caplog, mocker
+    ) -> None:
+        """Ensure warnings are logged when SECRETS_DIR has issues."""
+        app = FastAPI()
+        mock_session = mocker.patch(self.mock_session)
+        mock_connection = (
+            mock_session.return_value.__aenter__.return_value.connection
+        )
+        mock_connection.return_value = None
+
+        mocker.patch("app.main.get_settings").return_value.cache_enabled = False
+        mocker.patch("app.main.cors_list", ["https://example.com"])
+        mocker.patch(
+            "app.main.check_secrets_dir",
+            return_value=["SECRETS_DIR is writable by the current process."],
+        )
+        loguru_warning = mocker.patch("app.main.loguru_logger.warning")
+
+        caplog.set_level(logging.WARNING)
+
+        async with lifespan(app):
+            pass  # NOSONAR
+
+        assert any(
+            "SECRETS_DIR is writable" in record.message
+            for record in caplog.records
+        )
+        loguru_warning.assert_called_once()
+
     async def test_lifespan_initializes_redis_and_closes_client(
         self, caplog, mocker
     ) -> None:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -481,6 +481,13 @@ class TestSettingsSources:
         assert encryption_key
         assert Fernet(encryption_key.encode())
 
+    def test_none_admin_encryption_key_generates_default(self) -> None:
+        """None admin encryption key should generate a valid key."""
+        result = Settings.validate_admin_pages_encryption_key(None)
+
+        assert isinstance(result, SecretStr)
+        assert Fernet(unwrap_secret(result).encode())
+
     def test_get_settings_uses_secrets_dir_env_var(
         self, monkeypatch, mocker
     ) -> None:


### PR DESCRIPTION
## Summary
- Add lifespan test for SECRETS_DIR warning logging (covers `app/main.py:78-79`)
- Add validator test for `None` admin encryption key (covers `app/config/settings.py:246`)
- Brings total coverage from 99% (3 misses) to 100% (0 misses) across all 2500 app statements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for lifespan warnings related to secrets directory configuration.
  * Added unit tests for automatic encryption key generation for admin pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->