### PR TITLE
update `mako` package to fix security alert

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -189,7 +189,7 @@ limits==5.6.0
     # via slowapi
 loguru==0.7.3
     # via api-template
-mako==1.3.9
+mako==1.3.11
     # via alembic
 markdown==3.10.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ limits==5.6.0
     # via slowapi
 loguru==0.7.3
     # via api-template
-mako==1.3.9
+mako==1.3.11
     # via alembic
 markdown-it-py==3.0.0
     # via rich

--- a/uv.lock
+++ b/uv.lock
@@ -1487,14 +1487,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.9"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/4f/ddb1965901bc388958db9f0c991255b2c469349a741ae8c9cd8a562d70a6/mako-1.3.9.tar.gz", hash = "sha256:b5d65ff3462870feec922dbccf38f6efb44e5714d7b593a656be86663d8600ac", size = 392195, upload-time = "2025-02-04T15:05:49.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/83/de0a49e7de540513f53ab5d2e105321dedeb08a8f5850f0208decf4390ec/Mako-1.3.9-py3-none-any.whl", hash = "sha256:95920acccb578427a9aa38e37a186b1e43156c87260d7ba18ca63aa4c7cbd3a1", size = 78456, upload-time = "2025-02-04T15:05:51.115Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Package `mako` which is a transient dependecy for `jinja2`, `mkdocs` and more had an open security alert. Updated to the latest version to fix this.