### PR TITLE
chore: comprehensive .dockerignore for optimized builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,97 @@
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+
+# Virtual environments
 .venv
+venv/
+env/
+ENV/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.pytest_cache/
+.mypy_cache/
+.pyre/
+.pytype/
+.hypothesis/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+*.egg
+.installed.cfg
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.history/
+.ionide
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment and secrets
+.env
+.envrc
+.venv
+
+# Docker support files
+docker-compose.yml
+docker-compose*.yml
+docker_support/
+Dockerfile
+.dockerignore
+
+# Project docs (not needed at runtime)
+docs/
+mkdocs.yml
+CHANGELOG.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+SECURITY-REVIEW.md
+TODO.md
+
+# Tests (not needed at runtime)
+tests/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+nosetests.xml
+
+# Logs
+logs/
+*.log
+*.log.*
+
+# Runtime data
+data/
+volumes/
+redis/
+prometheus-test/
+
+# Config files
+.pre-commit-config.yaml
+.pylintrc
+.markdownlint.json
+alembic_scripting.ini
+
+# Static analysis
+mypy_report/
+
+


### PR DESCRIPTION
Expand the minimal .dockerignore (3 entries) to a comprehensive set that:

- Excludes git/CI files, Python caches, build artifacts, IDE files, OS files
- Excludes secrets, tests, docs, logs, and runtime data volumes
- Retains pyproject.toml, uv.lock, and README.md needed by the Dockerfile

Reduces build context size and prevents secrets from leaking into images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimised Docker image builds by expanding the `.dockerignore` file to exclude unnecessary files and directories, including version control metadata, virtual environments, build artefacts, cache directories, editor configurations, and test outputs, resulting in smaller and faster Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->