### PR TITLE
test: add xdist and transactional database fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,8 @@ module = "decouple.*"
 addopts = [
   "-m",
   "not rewrite",  # mark tests 'rewrite' that need work, and they wont be run
+  "-n",
+  "logical",
   "--cov",
   "--cov-report",
   "term-missing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
   "ty>=0.0.5",
   "prek>=0.2.24",
   "types-redis>=4.6.0.20241004",
+  "pytest-xdist>=3.8.0",
 ]
 
 [tool.uv.sources]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -117,6 +117,8 @@ exceptiongroup==1.2.2 ; python_full_version < '3.11'
     # via
     #   anyio
     #   pytest
+execnet==2.1.2
+    # via pytest-xdist
 faker==40.18.0
 fastapi==0.136.1
     # via
@@ -338,6 +340,7 @@ pytest==9.0.3
     #   pytest-randomly
     #   pytest-reverse
     #   pytest-sugar
+    #   pytest-xdist
 pytest-asyncio==1.3.0
 pytest-clarity==1.0.1
 pytest-cov==6.0.0
@@ -347,6 +350,7 @@ pytest-randomly==3.16.0
 pytest-reverse==1.8.0
 pytest-sugar==1.0.0
 pytest-watcher==0.4.3
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via
     #   ghp-import

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,8 +170,10 @@ async def client(
         headers={"Content-Type": "application/json"},
         timeout=10,
     ) as client:
-        yield client
-    app.dependency_overrides = {}
+        try:
+            yield client
+        finally:
+            app.dependency_overrides = {}
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
@@ -31,8 +32,13 @@ if TYPE_CHECKING:
     from pyfakefs.fake_filesystem import FakeFilesystem
 
 
+def _is_xdist_worker(config: pytest.Config) -> bool:
+    """Return whether this process is an xdist worker."""
+    return hasattr(config, "workerinput")
+
+
 @pytest.hookimpl(tryfirst=True)
-def pytest_configure(config) -> None:
+def pytest_configure(config: pytest.Config) -> None:
     """Clear the screen before running tests."""
     os.system("cls" if os.name == "nt" else "clear")  # noqa: S605
 
@@ -63,12 +69,7 @@ def create_test_engine() -> AsyncEngine:
     )
 
 
-def _is_xdist_worker(config) -> bool:
-    """Return whether this process is an xdist worker."""
-    return hasattr(config, "workerinput")
-
-
-def pytest_sessionstart(session) -> None:
+def pytest_sessionstart(session: pytest.Session) -> None:
     """Create the test schema before tests run."""
     if _is_xdist_worker(session.config):
         return
@@ -76,7 +77,7 @@ def pytest_sessionstart(session) -> None:
     asyncio.run(_create_test_schema())
 
 
-def pytest_sessionfinish(session, exitstatus) -> None:
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """Drop the test schema after tests finish."""
     if _is_xdist_worker(session.config):
         return
@@ -114,36 +115,50 @@ async def test_engine() -> AsyncGenerator[AsyncEngine, Any]:
 
 
 @pytest_asyncio.fixture()
-async def test_db(
+async def test_connection(
     test_engine: AsyncEngine,
-) -> AsyncGenerator[AsyncSession, Any]:
-    """Fixture to yield a database connection for testing."""
+) -> AsyncGenerator[AsyncConnection, Any]:
+    """Return a rollback-only test database connection."""
     async with test_engine.connect() as connection:
         transaction = await connection.begin()
-        test_session = async_sessionmaker(
-            bind=connection,
-            expire_on_commit=False,
-            join_transaction_mode="create_savepoint",
-        )
-        session = test_session()
-
         try:
-            yield session
+            yield connection
         finally:
-            await session.close()
             if transaction.is_active:
                 await transaction.rollback()
 
 
 @pytest_asyncio.fixture()
+async def test_sessionmaker(
+    test_connection: AsyncConnection,
+) -> async_sessionmaker[AsyncSession]:
+    """Return a session maker bound to the test connection."""
+    return async_sessionmaker(
+        bind=test_connection,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+
+
+@pytest_asyncio.fixture()
+async def test_db(
+    test_sessionmaker: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, Any]:
+    """Fixture to yield a database connection for testing."""
+    async with test_sessionmaker() as session:
+        yield session
+
+
+@pytest_asyncio.fixture()
 async def client(
-    test_db: AsyncSession,
+    test_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncClient, Any]:
     """Fixture to yield a test client for the app."""
 
     async def get_database_override() -> AsyncGenerator[AsyncSession, Any]:
         """Return the database connection for testing."""
-        yield test_db
+        async with test_sessionmaker() as session, session.begin():
+            yield session
 
     app.dependency_overrides[get_database] = get_database_override
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -10,10 +11,17 @@ import pytest_asyncio
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
 from typer.testing import CliRunner
 
 from app.config.helpers import get_project_root
-from app.database.db import Base, create_session_maker, get_database
+from app.database.db import Base, get_database, get_database_url
 from app.main import app
 from app.managers.email import EmailManager
 
@@ -21,21 +29,59 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
     from pyfakefs.fake_filesystem import FakeFilesystem
-    from sqlalchemy.ext.asyncio import (
-        AsyncSession,
-    )
-
-
-# Create session maker using the function that handles environment detection
-# Pass use_test_db=True to ensure we use the test database
-async_test_session = create_session_maker(use_test_db=True)
-async_engine = async_test_session.kw["bind"]
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config) -> None:
     """Clear the screen before running tests."""
     os.system("cls" if os.name == "nt" else "clear")  # noqa: S605
+
+
+async def _create_test_schema() -> None:
+    """Create the test database schema."""
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    await engine.dispose()
+
+
+async def _drop_test_schema() -> None:
+    """Drop the test database schema."""
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+def create_test_engine() -> AsyncEngine:
+    """Create an async engine for the test database."""
+    return create_async_engine(
+        get_database_url(use_test_db=True),
+        echo=False,
+        poolclass=NullPool,
+    )
+
+
+def _is_xdist_worker(config) -> bool:
+    """Return whether this process is an xdist worker."""
+    return hasattr(config, "workerinput")
+
+
+def pytest_sessionstart(session) -> None:
+    """Create the test schema before tests run."""
+    if _is_xdist_worker(session.config):
+        return
+
+    asyncio.run(_create_test_schema())
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """Drop the test schema after tests finish."""
+    if _is_xdist_worker(session.config):
+        return
+
+    asyncio.run(_drop_test_schema())
 
 
 # Initialize cache backend if needed and clear before each test
@@ -57,36 +103,48 @@ async def init_and_clear_cache() -> None:
     await FastAPICache.clear()
 
 
-# reset the database before each test
-@pytest_asyncio.fixture(autouse=True, scope="function")
-async def reset_db() -> None:
-    """Reset the database."""
-    # Close any existing connections
-    await async_engine.dispose()
-
-    # Recreate all tables
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-        await conn.run_sync(Base.metadata.create_all)
-
-
-# Override the database connection to use the test database
-async def get_database_override() -> AsyncGenerator[AsyncSession, Any]:
-    """Return the database connection for testing."""
-    async with async_test_session() as session, session.begin():
-        yield session
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def test_engine() -> AsyncGenerator[AsyncEngine, Any]:
+    """Return the test database engine."""
+    engine = create_test_engine()
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
 
 
 @pytest_asyncio.fixture()
-async def test_db() -> AsyncGenerator[AsyncSession, Any]:
+async def test_db(
+    test_engine: AsyncEngine,
+) -> AsyncGenerator[AsyncSession, Any]:
     """Fixture to yield a database connection for testing."""
-    async with async_test_session() as session, session.begin():
-        yield session
+    async with test_engine.connect() as connection:
+        transaction = await connection.begin()
+        test_session = async_sessionmaker(
+            bind=connection,
+            expire_on_commit=False,
+            join_transaction_mode="create_savepoint",
+        )
+        session = test_session()
+
+        try:
+            yield session
+        finally:
+            await session.close()
+            if transaction.is_active:
+                await transaction.rollback()
 
 
 @pytest_asyncio.fixture()
-async def client() -> AsyncGenerator[AsyncClient, Any]:
+async def client(
+    test_db: AsyncSession,
+) -> AsyncGenerator[AsyncClient, Any]:
     """Fixture to yield a test client for the app."""
+
+    async def get_database_override() -> AsyncGenerator[AsyncSession, Any]:
+        """Return the database connection for testing."""
+        yield test_db
+
     app.dependency_overrides[get_database] = get_database_override
 
     transport = ASGITransport(app=app)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,8 +1,14 @@
 """Some helper functions for testing."""
 
+from typing import Any
+
 import jwt
+from fastapi import BackgroundTasks
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.settings import get_settings, unwrap_secret
+from app.managers.user import UserManager
+from app.models.user import User
 
 
 def get_token(sub: int, exp: float, typ: str) -> str:
@@ -16,3 +22,13 @@ def get_token(sub: int, exp: float, typ: str) -> str:
         unwrap_secret(get_settings().secret_key),
         algorithm="HS256",
     )
+
+
+async def register_and_get_user(
+    test_db: AsyncSession,
+    user_data: dict[str, Any],
+    background_tasks: BackgroundTasks | None = None,
+) -> User:
+    """Register a user and return the persisted model."""
+    await UserManager.register(user_data, test_db, background_tasks)
+    return await UserManager.get_user_by_email(user_data["email"], test_db)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,5 +30,7 @@ async def register_and_get_user(
     background_tasks: BackgroundTasks | None = None,
 ) -> User:
     """Register a user and return the persisted model."""
-    await UserManager.register(user_data, test_db, background_tasks)
+    await UserManager.register(
+        user_data, test_db, background_tasks=background_tasks
+    )
     return await UserManager.get_user_by_email(user_data["email"], test_db)

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database.helpers import hash_password
 from app.models.enums import RoleType
 from app.models.user import User
-from tests.conftest import async_test_session
 
 
 @pytest.mark.asyncio
@@ -120,19 +119,9 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        # create a new db session and add the admin user again because the
-        # session is closed and obviously rolled back after the first request.
-        # This is annoying and need to find a better way to handle this.
-        async with async_test_session() as new_session:
-            new_session.begin()
-            new_session.add(admin_user)
-            await new_session.flush()
-
-            mocker.patch(
-                "app.admin.auth.async_session", return_value=new_session
-            )
-            client.cookies = cookies
-            response = await client.get(route, follow_redirects=True)
+        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        client.cookies = cookies
+        response = await client.get(route, follow_redirects=True)
 
         assert response.status_code == status.HTTP_200_OK
         assert route in str(response.url)
@@ -159,23 +148,13 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        async with async_test_session() as new_session:
-            new_session.begin()
-            new_session.add(admin_user)
-            await new_session.flush()
+        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.AdminAuth._decode_token", return_value=False
+        )
 
-            mocker.patch(
-                "app.admin.auth.async_session", return_value=new_session
-            )
-
-            mocker.patch(
-                "app.admin.auth.AdminAuth._decode_token", return_value=False
-            )
-
-            client.cookies = cookies
-            response = await client.get(
-                "/admin/user/list", follow_redirects=True
-            )
+        client.cookies = cookies
+        response = await client.get("/admin/user/list", follow_redirects=True)
 
         assert response.status_code == status.HTTP_200_OK
         assert "admin/login" in str(response.url)
@@ -202,23 +181,13 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        # bit of a bodge here, but we need to update the user to be a normal
-        # user and keep the same id as in the session.
-        async with async_test_session() as new_session:
-            new_session.begin()
-            user = User(**self.get_test_user(admin=False))
-            user.id = admin_user.id
-            new_session.add(user)
-            await new_session.flush()
+        admin_user.role = RoleType.user
+        await test_db.flush()
 
-            mocker.patch(
-                "app.admin.auth.async_session", return_value=new_session
-            )
+        mocker.patch("app.admin.auth.async_session", return_value=test_db)
 
-            client.cookies = cookies
-            response = await client.get(
-                "/admin/user/list", follow_redirects=True
-            )
+        client.cookies = cookies
+        response = await client.get("/admin/user/list", follow_redirects=True)
 
         assert response.status_code == status.HTTP_200_OK
         assert "admin/login" in str(response.url)
@@ -245,24 +214,13 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        # bit of a bodge here, but we need to update the user to be banned
-        # user and keep the same id as in the session.
-        async with async_test_session() as new_session:
-            new_session.begin()
-            user = User(**self.get_test_user(admin=True))
-            user.banned = True
-            user.id = admin_user.id
-            new_session.add(user)
-            await new_session.flush()
+        admin_user.banned = True
+        await test_db.flush()
 
-            mocker.patch(
-                "app.admin.auth.async_session", return_value=new_session
-            )
+        mocker.patch("app.admin.auth.async_session", return_value=test_db)
 
-            client.cookies = cookies
-            response = await client.get(
-                "/admin/user/list", follow_redirects=True
-            )
+        client.cookies = cookies
+        response = await client.get("/admin/user/list", follow_redirects=True)
 
         assert response.status_code == status.HTTP_200_OK
         assert "admin/login" in str(response.url)

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -69,14 +69,21 @@ class TestAdminAuth:
         assert "Password" in response.text
 
     async def test_admin_login_ok(
-        self, client: AsyncClient, test_db: AsyncSession, mocker
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
     ) -> None:
         """Test that the admin login page works with valid credentials."""
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         route = "/admin/login"
         data = {"username": admin_user.email, "password": "test12345!"}
@@ -98,14 +105,22 @@ class TestAdminAuth:
         ],
     )
     async def test_authenticated_user_access_admin_routes(
-        self, client: AsyncClient, test_db: AsyncSession, mocker, route
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
+        route,
     ) -> None:
         """Test that the admin login page works with valid credentials."""
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         # login the user first
         data = {"username": admin_user.email, "password": "test12345!"}
@@ -119,7 +134,6 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
         client.cookies = cookies
         response = await client.get(route, follow_redirects=True)
 
@@ -127,14 +141,21 @@ class TestAdminAuth:
         assert route in str(response.url)
 
     async def test_bad_token_in_session_redirects_to_login(
-        self, client: AsyncClient, test_db: AsyncSession, mocker
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
     ) -> None:
         """Test that a bad token in the session redirects to login."""
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         # login the user first
         data = {"username": admin_user.email, "password": "test12345!"}
@@ -148,7 +169,6 @@ class TestAdminAuth:
         assert response.cookies.get("session") is not None
         cookies = response.cookies
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
         mocker.patch(
             "app.admin.auth.AdminAuth._decode_token", return_value=False
         )
@@ -160,14 +180,21 @@ class TestAdminAuth:
         assert "admin/login" in str(response.url)
 
     async def test_downgraded_admin_redirects_to_login(
-        self, client: AsyncClient, test_db: AsyncSession, mocker
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
     ) -> None:
         """Test if a valid admin is downgraded, it redirects to login."""
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         # login the user first
         data = {"username": admin_user.email, "password": "test12345!"}
@@ -182,9 +209,7 @@ class TestAdminAuth:
         cookies = response.cookies
 
         admin_user.role = RoleType.user
-        await test_db.flush()
-
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        await test_db.commit()
 
         client.cookies = cookies
         response = await client.get("/admin/user/list", follow_redirects=True)
@@ -193,14 +218,21 @@ class TestAdminAuth:
         assert "admin/login" in str(response.url)
 
     async def test_banned_admin_redirects_to_login(
-        self, client: AsyncClient, test_db: AsyncSession, mocker
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
     ) -> None:
         """Test if a valid admin is downgraded, it redirects to login."""
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         # login the user first
         data = {"username": admin_user.email, "password": "test12345!"}
@@ -215,9 +247,7 @@ class TestAdminAuth:
         cookies = response.cookies
 
         admin_user.banned = True
-        await test_db.flush()
-
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        await test_db.commit()
 
         client.cookies = cookies
         response = await client.get("/admin/user/list", follow_redirects=True)
@@ -226,17 +256,24 @@ class TestAdminAuth:
         assert "admin/login" in str(response.url)
 
     async def test_non_admin_login_fails(
-        self, client: AsyncClient, test_db: AsyncSession, mocker
+        self,
+        client: AsyncClient,
+        test_db: AsyncSession,
+        test_sessionmaker,
+        mocker,
     ) -> None:
         """Test that a non-admin user cannot login to the admin interface."""
         plain_user = User(**self.get_test_user())
         test_db.add(plain_user)
 
-        await test_db.flush()
+        await test_db.commit()
 
         data = {"username": plain_user.email, "password": "test12345!"}
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         route = "/admin/login"
         response = await client.post(
@@ -261,6 +298,7 @@ class TestAdminAuth:
         self,
         client: AsyncClient,
         test_db: AsyncSession,
+        test_sessionmaker,
         mocker,
         credentials,
     ) -> None:
@@ -269,9 +307,12 @@ class TestAdminAuth:
 
         admin_user = User(**self.get_test_user(admin=True))
         test_db.add(admin_user)
-        await test_db.flush()
+        await test_db.commit()
 
-        mocker.patch("app.admin.auth.async_session", return_value=test_db)
+        mocker.patch(
+            "app.admin.auth.async_session",
+            side_effect=test_sessionmaker,
+        )
 
         route = "/admin/login"
         data = {"username": username, "password": password}

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -11,6 +11,7 @@ from app.database.helpers import hash_password, verify_password
 from app.managers.auth import AuthManager
 from app.managers.helpers import BCRYPT_PASSWORD_MAX_BYTES
 from app.managers.user import ErrorMessages as UserErrorMessages
+from app.managers.user import UserManager
 from app.models.enums import RoleType
 from app.models.user import User
 from app.schemas.password import LOGIN_PASSWORD_MAX_BYTES_ERROR
@@ -79,7 +80,9 @@ class TestAuthRoutes:
         assert isinstance(response.json()["token"], str)
         assert isinstance(response.json()["refresh"], str)
 
-        user_from_db = await test_db.get(User, 1)
+        user_from_db = await UserManager.get_user_by_email(
+            post_body["email"], test_db
+        )
 
         if user_from_db is None:
             pytest.fail("User was not added to the database")
@@ -140,7 +143,9 @@ class TestAuthRoutes:
             json=post_body,
         )
 
-        user_from_db = await test_db.get(User, 1)
+        user_from_db = await UserManager.get_user_by_email(
+            post_body["email"], test_db
+        )
 
         assert user_from_db.password != post_body["password"]
         assert verify_password(post_body["password"], user_from_db.password)
@@ -480,10 +485,14 @@ class TestAuthRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test we can verify a user."""
-        test_db.add(User(**self.test_unverified_user))
+        test_user = User(**self.test_unverified_user)
+        test_db.add(test_user)
+        await test_db.flush()
         await test_db.commit()
 
-        verification_token = AuthManager.encode_verify_token(User(id=1))
+        verification_token = AuthManager.encode_verify_token(
+            User(id=test_user.id)
+        )
 
         response = await client.get(
             "/verify/", params={"code": verification_token}

--- a/tests/integration/test_user_routes.py
+++ b/tests/integration/test_user_routes.py
@@ -39,6 +39,14 @@ class TestUserRoutes:
             "role": RoleType.admin if admin else RoleType.user,
         }
 
+    async def add_users(
+        self, test_db: AsyncSession, *users: User
+    ) -> tuple[User, ...]:
+        """Add users to the test session and populate generated IDs."""
+        test_db.add_all(users)
+        await test_db.flush()
+        return users
+
     # ------------------------------------------------------------------------ #
     #                            test profile route                            #
     # ------------------------------------------------------------------------ #
@@ -108,36 +116,42 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure an admin user can get one users."""
+        users: list[User] = []
         for i in range(3):
             user_data = self.get_test_user()
             if i > 0:
                 user_data["email"] = f"user{i}@test.com"
             test_user = User(**user_data)
-            test_db.add(test_user)
+            users.append(test_user)
 
         admin_user = User(**self.get_test_user(admin=True))
-        test_db.add(admin_user)
+        test_db.add_all([*users, admin_user])
+        await test_db.flush()
         await test_db.commit()
         token = AuthManager.encode_token(admin_user)
 
         response = await client.get(
-            "/users/?user_id=3", headers={"Authorization": f"Bearer {token}"}
+            f"/users/?user_id={users[2].id}",
+            headers={"Authorization": f"Bearer {token}"},
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()["id"] == 3  # noqa: PLR2004
+        assert response.json()["id"] == users[2].id
 
     async def test_user_cant_get_all_users(
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test we can't get all users if not admin."""
+        users: list[User] = []
         for i in range(3):
             user_data = self.get_test_user()
             if i > 0:
                 user_data["email"] = f"user{i}@test.com"
             test_user = User(**user_data)
-            test_db.add(test_user)
-        token = AuthManager.encode_token(User(id=1))
+            users.append(test_user)
+        test_db.add_all(users)
+        await test_db.flush()
+        token = AuthManager.encode_token(User(id=users[0].id))
 
         await test_db.commit()
 
@@ -152,18 +166,22 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test we can't get all users if not admin."""
+        users: list[User] = []
         for i in range(3):
             user_data = self.get_test_user()
             if i > 0:
                 user_data["email"] = f"user{i}@test.com"
             test_user = User(**user_data)
-            test_db.add(test_user)
-        token = AuthManager.encode_token(User(id=1))
+            users.append(test_user)
+        test_db.add_all(users)
+        await test_db.flush()
+        token = AuthManager.encode_token(User(id=users[0].id))
 
         await test_db.commit()
 
         response = await client.get(
-            "/users/?user_id=2", headers={"Authorization": f"Bearer {token}"}
+            f"/users/?user_id={users[1].id}",
+            headers={"Authorization": f"Bearer {token}"},
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -179,18 +197,19 @@ class TestUserRoutes:
         normal_user = self.get_test_user()
         admin_user = self.get_test_user(admin=True)
 
-        test_db.add(User(**normal_user))
-        test_db.add(User(**admin_user))
-        token = AuthManager.encode_token(User(id=2))
+        normal_model, admin_model = await self.add_users(
+            test_db, User(**normal_user), User(**admin_user)
+        )
+        token = AuthManager.encode_token(User(id=admin_model.id))
 
         await test_db.commit()
 
         upgrade_user = await client.post(
-            "/users/1/make-admin",
+            f"/users/{normal_model.id}/make-admin",
             headers={"Authorization": f"Bearer {token}"},
         )
         new_admin = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={normal_model.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -206,19 +225,20 @@ class TestUserRoutes:
         normal_user_2 = self.get_test_user()
         normal_user_2["email"] = "user2@test.com"
 
-        test_db.add(User(**normal_user))
-        test_db.add(User(**normal_user_2))
-        token = AuthManager.encode_token(User(id=1))
+        user1, user2 = await self.add_users(
+            test_db, User(**normal_user), User(**normal_user_2)
+        )
+        token = AuthManager.encode_token(User(id=user1.id))
 
         await test_db.commit()
 
         upgrade_user = await client.post(
-            "/users/2/make-admin",
+            f"/users/{user2.id}/make-admin",
             headers={"Authorization": f"Bearer {token}"},
         )
 
         new_admin = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={user2.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -235,19 +255,20 @@ class TestUserRoutes:
         normal_user = self.get_test_user()
         admin_user = self.get_test_user(admin=True)
 
-        test_db.add(User(**normal_user))
-        test_db.add(User(**admin_user))
-        token = AuthManager.encode_token(User(id=2))
+        normal_model, admin_model = await self.add_users(
+            test_db, User(**normal_user), User(**admin_user)
+        )
+        token = AuthManager.encode_token(User(id=admin_model.id))
 
         await test_db.commit()
 
         banned_response = await client.post(
-            "/users/1/ban",
+            f"/users/{normal_model.id}/ban",
             headers={"Authorization": f"Bearer {token}"},
         )
 
         banned_user = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={normal_model.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -292,21 +313,21 @@ class TestUserRoutes:
         user3 = self.get_test_user(admin=True)
         user2["email"] = "user2@test.com"
         user3["email"] = "admin@test.com"
-        test_db.add(User(**user1))
-        test_db.add(User(**user2))
-        test_db.add(User(**user3))
-        token = AuthManager.encode_token(User(id=1))
-        admin_token = AuthManager.encode_token(User(id=3))
+        user1_model, user2_model, user3_model = await self.add_users(
+            test_db, User(**user1), User(**user2), User(**user3)
+        )
+        token = AuthManager.encode_token(User(id=user1_model.id))
+        admin_token = AuthManager.encode_token(User(id=user3_model.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/2/ban",
+            f"/users/{user2_model.id}/ban",
             headers={"Authorization": f"Bearer {token}"},
         )
 
         banned_user = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={user2_model.id}",
             headers={"Authorization": f"Bearer {admin_token}"},
         )
 
@@ -318,8 +339,10 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure an admin cant unban user that does not exist."""
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=1))
+        (admin_user,) = await self.add_users(
+            test_db, User(**self.get_test_user(admin=True))
+        )
+        token = AuthManager.encode_token(User(id=admin_user.id))
 
         await test_db.commit()
 
@@ -341,18 +364,19 @@ class TestUserRoutes:
         normal_user = {**self.get_test_user(), "banned": True}
         admin_user = self.get_test_user(admin=True)
 
-        test_db.add(User(**normal_user))
-        test_db.add(User(**admin_user))
-        token = AuthManager.encode_token(User(id=2))
+        normal_model, admin_model = await self.add_users(
+            test_db, User(**normal_user), User(**admin_user)
+        )
+        token = AuthManager.encode_token(User(id=admin_model.id))
 
         await test_db.commit()
 
         unban_response = await client.post(
-            "/users/1/unban",
+            f"/users/{normal_model.id}/unban",
             headers={"Authorization": f"Bearer {token}"},
         )
         banned_user = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={normal_model.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -365,13 +389,13 @@ class TestUserRoutes:
     ) -> None:
         """Ensure an admin cant unban self."""
         admin_user = {**self.get_test_user(admin=True), "banned": True}
-        test_db.add(User(**admin_user))
-        token = AuthManager.encode_token(User(id=1))
+        (admin_model,) = await self.add_users(test_db, User(**admin_user))
+        token = AuthManager.encode_token(User(id=admin_model.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/1/unban",
+            f"/users/{admin_model.id}/unban",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -381,8 +405,10 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure an admin cant unban user that does not exist."""
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=1))
+        (admin_user,) = await self.add_users(
+            test_db, User(**self.get_test_user(admin=True))
+        )
+        token = AuthManager.encode_token(User(id=admin_user.id))
 
         await test_db.commit()
 
@@ -398,14 +424,17 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure a non-admin cant unban another user."""
-        test_db.add(User(**self.get_test_user()))
-        test_db.add(User(**{**self.get_test_user(), "banned": True}))
-        token = AuthManager.encode_token(User(id=1))
+        user1, user2 = await self.add_users(
+            test_db,
+            User(**self.get_test_user()),
+            User(**{**self.get_test_user(), "banned": True}),
+        )
+        token = AuthManager.encode_token(User(id=user1.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/2/unban",
+            f"/users/{user2.id}/unban",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -418,19 +447,22 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test that an admin can delete a user."""
-        test_db.add(User(**self.get_test_user()))
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=2))
+        user, admin = await self.add_users(
+            test_db,
+            User(**self.get_test_user()),
+            User(**self.get_test_user(admin=True)),
+        )
+        token = AuthManager.encode_token(User(id=admin.id))
 
         await test_db.commit()
 
         await client.delete(
-            "/users/1",
+            f"/users/{user.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
         response = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={user.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -445,21 +477,21 @@ class TestUserRoutes:
         user3 = self.get_test_user(admin=True)
         user2["email"] = "user2@test.com"
         user3["email"] = "admin@test.com"
-        test_db.add(User(**user1))
-        test_db.add(User(**user2))
-        test_db.add(User(**user3))
-        token = AuthManager.encode_token(User(id=1))
-        admin_token = AuthManager.encode_token(User(id=3))
+        user1_model, user2_model, user3_model = await self.add_users(
+            test_db, User(**user1), User(**user2), User(**user3)
+        )
+        token = AuthManager.encode_token(User(id=user1_model.id))
+        admin_token = AuthManager.encode_token(User(id=user3_model.id))
 
         await test_db.commit()
 
         response = await client.delete(
-            "/users/2",
+            f"/users/{user2_model.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
         not_deleted_user = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={user2_model.id}",
             headers={"Authorization": f"Bearer {admin_token}"},
         )
 
@@ -470,8 +502,10 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test deleting a non-existing user."""
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=1))
+        (admin_user,) = await self.add_users(
+            test_db, User(**self.get_test_user(admin=True))
+        )
+        token = AuthManager.encode_token(User(id=admin_user.id))
 
         await test_db.commit()
 
@@ -487,13 +521,17 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test that the only admin cannot delete themselves."""
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=1, role=RoleType.admin))
+        (admin_user,) = await self.add_users(
+            test_db, User(**self.get_test_user(admin=True))
+        )
+        token = AuthManager.encode_token(
+            User(id=admin_user.id, role=RoleType.admin)
+        )
 
         await test_db.commit()
 
         response = await client.delete(
-            "/users/1",
+            f"/users/{admin_user.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -503,7 +541,7 @@ class TestUserRoutes:
 
         # Verify user still exists
         check_user = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={admin_user.id}",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert check_user.status_code == status.HTTP_200_OK
@@ -515,16 +553,21 @@ class TestUserRoutes:
         user1 = self.get_test_user(admin=True)
         user2 = self.get_test_user(admin=True)
         user2["email"] = "admin2@test.com"
-        test_db.add(User(**user1))
-        test_db.add(User(**user2))
-        token1 = AuthManager.encode_token(User(id=1, role=RoleType.admin))
-        token2 = AuthManager.encode_token(User(id=2, role=RoleType.admin))
+        admin1, admin2 = await self.add_users(
+            test_db, User(**user1), User(**user2)
+        )
+        token1 = AuthManager.encode_token(
+            User(id=admin1.id, role=RoleType.admin)
+        )
+        token2 = AuthManager.encode_token(
+            User(id=admin2.id, role=RoleType.admin)
+        )
 
         await test_db.commit()
 
         # Admin 1 deletes themselves
         response = await client.delete(
-            "/users/1",
+            f"/users/{admin1.id}",
             headers={"Authorization": f"Bearer {token1}"},
         )
 
@@ -533,14 +576,14 @@ class TestUserRoutes:
 
         # Verify admin 1 no longer exists
         check_deleted = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={admin1.id}",
             headers={"Authorization": f"Bearer {token2}"},
         )
         assert check_deleted.status_code == status.HTTP_404_NOT_FOUND
 
         # Verify admin 2 still exists
         check_remaining = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={admin2.id}",
             headers={"Authorization": f"Bearer {token2}"},
         )
         assert check_remaining.status_code == status.HTTP_200_OK
@@ -549,15 +592,20 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Test that the only admin can delete regular users."""
-        test_db.add(User(**self.get_test_user(admin=True)))
-        test_db.add(User(**self.get_test_user(admin=False)))
-        admin_token = AuthManager.encode_token(User(id=1, role=RoleType.admin))
+        admin_user, regular_user = await self.add_users(
+            test_db,
+            User(**self.get_test_user(admin=True)),
+            User(**self.get_test_user(admin=False)),
+        )
+        admin_token = AuthManager.encode_token(
+            User(id=admin_user.id, role=RoleType.admin)
+        )
 
         await test_db.commit()
 
         # Admin deletes regular user
         response = await client.delete(
-            "/users/2",
+            f"/users/{regular_user.id}",
             headers={"Authorization": f"Bearer {admin_token}"},
         )
 
@@ -566,7 +614,7 @@ class TestUserRoutes:
 
         # Verify user no longer exists
         check_deleted = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={regular_user.id}",
             headers={"Authorization": f"Bearer {admin_token}"},
         )
         assert check_deleted.status_code == status.HTTP_404_NOT_FOUND
@@ -578,15 +626,18 @@ class TestUserRoutes:
         user1 = self.get_test_user(admin=True)
         user2 = self.get_test_user(admin=True)
         user2["email"] = "admin2@test.com"
-        test_db.add(User(**user1))
-        test_db.add(User(**user2))
-        admin1_token = AuthManager.encode_token(User(id=1, role=RoleType.admin))
+        admin1, admin2 = await self.add_users(
+            test_db, User(**user1), User(**user2)
+        )
+        admin1_token = AuthManager.encode_token(
+            User(id=admin1.id, role=RoleType.admin)
+        )
 
         await test_db.commit()
 
         # Admin 1 deletes Admin 2 (cross-admin deletion)
         response = await client.delete(
-            "/users/2",
+            f"/users/{admin2.id}",
             headers={"Authorization": f"Bearer {admin1_token}"},
         )
 
@@ -595,14 +646,14 @@ class TestUserRoutes:
 
         # Verify admin 2 no longer exists
         check_deleted = await client.get(
-            "/users/?user_id=2",
+            f"/users/?user_id={admin2.id}",
             headers={"Authorization": f"Bearer {admin1_token}"},
         )
         assert check_deleted.status_code == status.HTTP_404_NOT_FOUND
 
         # Verify admin 1 still exists (use own token since admin2 is gone)
         check_remaining = await client.get(
-            "/users/?user_id=1",
+            f"/users/?user_id={admin1.id}",
             headers={"Authorization": f"Bearer {admin1_token}"},
         )
         assert check_remaining.status_code == status.HTTP_200_OK
@@ -658,8 +709,8 @@ class TestUserRoutes:
     ) -> None:
         """Test that a non-admin user cannot search users."""
         # Create regular user
-        test_db.add(User(**self.get_test_user()))
-        token = AuthManager.encode_token(User(id=1))
+        (user,) = await self.add_users(test_db, User(**self.get_test_user()))
+        token = AuthManager.encode_token(User(id=user.id))
 
         await test_db.commit()
 
@@ -794,13 +845,13 @@ class TestUserRoutes:
     ) -> None:
         """Ensure a user can change their own password."""
         user = self.get_test_user()
-        test_db.add(User(**user))
-        token = AuthManager.encode_token(User(id=1))
+        (user_model,) = await self.add_users(test_db, User(**user))
+        token = AuthManager.encode_token(User(id=user_model.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/1/password",
+            f"/users/{user_model.id}/password",
             json={"password": "new_password"},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -821,14 +872,15 @@ class TestUserRoutes:
         user2 = self.get_test_user()
         user2["email"] = "user2@test.com"
 
-        test_db.add(User(**user1))
-        test_db.add(User(**user2))
-        token = AuthManager.encode_token(User(id=1))
+        user1_model, user2_model = await self.add_users(
+            test_db, User(**user1), User(**user2)
+        )
+        token = AuthManager.encode_token(User(id=user1_model.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/2/password",
+            f"/users/{user2_model.id}/password",
             json={"password": "new_password"},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -847,14 +899,15 @@ class TestUserRoutes:
         """Ensure an admin user can change any user password."""
         normal_user = self.get_test_user()
         admin_user = self.get_test_user(admin=True)
-        test_db.add(User(**normal_user))
-        test_db.add(User(**admin_user))
-        token = AuthManager.encode_token(User(id=2))
+        normal_model, admin_model = await self.add_users(
+            test_db, User(**normal_user), User(**admin_user)
+        )
+        token = AuthManager.encode_token(User(id=admin_model.id))
 
         await test_db.commit()
 
         response = await client.post(
-            "/users/1/password",
+            f"/users/{normal_model.id}/password",
             json={"password": "new_password"},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -875,13 +928,13 @@ class TestUserRoutes:
     ) -> None:
         """Ensure a user can change their own details."""
         normal_user = self.get_test_user()
-        test_db.add(User(**normal_user))
-        token = AuthManager.encode_token(User(id=1))
+        (normal_model,) = await self.add_users(test_db, User(**normal_user))
+        token = AuthManager.encode_token(User(id=normal_model.id))
 
         await test_db.commit()
 
         response = await client.put(
-            "/users/1",
+            f"/users/{normal_model.id}",
             json={
                 "email": "new@example.com",
                 "password": "new_password",
@@ -902,14 +955,15 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure a user cant change other user password."""
-        test_db.add(User(**self.get_test_user()))
-        test_db.add(User(**self.get_test_user()))
-        token = AuthManager.encode_token(User(id=1))
+        user1, user2 = await self.add_users(
+            test_db, User(**self.get_test_user()), User(**self.get_test_user())
+        )
+        token = AuthManager.encode_token(User(id=user1.id))
 
         await test_db.commit()
 
         response = await client.put(
-            "/users/2",
+            f"/users/{user2.id}",
             json={
                 "email": "new@example.com",
                 "password": hash_password("new_password"),
@@ -925,14 +979,17 @@ class TestUserRoutes:
         self, client: AsyncClient, test_db: AsyncSession
     ) -> None:
         """Ensure an admin user can change any user password."""
-        test_db.add(User(**self.get_test_user()))
-        test_db.add(User(**self.get_test_user(admin=True)))
-        token = AuthManager.encode_token(User(id=2))
+        user, admin = await self.add_users(
+            test_db,
+            User(**self.get_test_user()),
+            User(**self.get_test_user(admin=True)),
+        )
+        token = AuthManager.encode_token(User(id=admin.id))
 
         await test_db.commit()
 
         response = await client.put(
-            "/users/1",
+            f"/users/{user.id}",
             json={
                 "email": "new@example.com",
                 "password": "new_password",

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -240,6 +240,9 @@ class TestAdminAuth:
         mocker.patch(
             "app.admin.auth.async_session", return_value=session_context
         )
-        mocker.patch("app.admin.auth.get_user_by_id_", return_value=admin_user)
+        get_user_by_id_mock = mocker.patch(
+            "app.admin.auth.get_user_by_id_", return_value=admin_user
+        )
 
         assert await auth_backend.authenticate(request) is True
+        get_user_by_id_mock.assert_awaited_once_with(admin_user.id, session)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -215,3 +215,31 @@ class TestAdminAuth:
         password = "x" * (BCRYPT_PASSWORD_MAX_BYTES + 1)
 
         assert auth_backend._validate_user(password, admin_user) is False
+
+    @pytest.mark.asyncio
+    async def test_authenticate_valid_admin_token(
+        self, auth_backend: AdminAuth, mocker
+    ) -> None:
+        """Test a valid admin session token authenticates successfully."""
+        admin_user = User(
+            id=1,
+            email="admin@test.com",
+            password=hash_password("password123"),
+            role=RoleType.admin,
+            banned=False,
+            first_name="Admin",
+            last_name="User",
+        )
+        token = auth_backend._create_token(admin_user.id)
+        request = mocker.Mock()
+        request.session = {"token": token}
+        session = mocker.Mock()
+        session_context = mocker.AsyncMock()
+        session_context.__aenter__.return_value = session
+
+        mocker.patch(
+            "app.admin.auth.async_session", return_value=session_context
+        )
+        mocker.patch("app.admin.auth.get_user_by_id_", return_value=admin_user)
+
+        assert await auth_backend.authenticate(request) is True

--- a/tests/unit/test_api_key_auth.py
+++ b/tests/unit/test_api_key_auth.py
@@ -43,7 +43,7 @@ class TestApiKeyAuth:
 
         assert isinstance(result, User)
         assert result.email == self.test_user["email"]
-        assert result.id == 1
+        assert result.id == user.id
 
     async def test_api_key_auth_invalid_key(self, test_db, mocker) -> None:
         """Test with an invalid API key."""

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -6,7 +6,6 @@ import jwt
 import pytest
 from fastapi import BackgroundTasks, HTTPException, status
 from pydantic import ValidationError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.settings import get_settings, unwrap_secret
 from app.database.helpers import verify_password
@@ -15,7 +14,7 @@ from app.managers.helpers import BCRYPT_PASSWORD_MAX_BYTES, MAX_JWT_TOKEN_LENGTH
 from app.managers.user import UserManager
 from app.models.user import User
 from app.schemas.request.auth import TokenRefreshRequest
-from tests.helpers import get_token
+from tests.helpers import get_token, register_and_get_user
 
 
 @pytest.mark.unit
@@ -28,19 +27,6 @@ class TestAuthManager:
         "first_name": "Test",
         "last_name": "User",
     }
-
-    async def _register_user(
-        self,
-        test_db: AsyncSession,
-        background_tasks: BackgroundTasks | None = None,
-    ) -> User:
-        """Register the default user and return the persisted model."""
-        await UserManager.register(
-            self.test_user, test_db, background_tasks=background_tasks
-        )
-        return await UserManager.get_user_by_email(
-            self.test_user["email"], test_db
-        )
 
     # ------------------------------------------------------------------------ #
     #                           test encoding tokens                           #
@@ -240,7 +226,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_refresh_banned_user(self, test_db) -> None:
         """Test the refresh method with a banned user."""
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
         banned_user_refresh = AuthManager.encode_refresh_token(User(id=user.id))
         new_token = None
@@ -259,7 +245,9 @@ class TestAuthManager:
     async def test_verify(self, test_db) -> None:
         """Test the verify method."""
         background_tasks = BackgroundTasks()
-        user = await self._register_user(test_db, background_tasks)
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
+        )
         verify_token = AuthManager.encode_verify_token(User(id=user.id))
         with pytest.raises(HTTPException) as exc_info:
             await AuthManager.verify(verify_token, test_db)
@@ -282,7 +270,9 @@ class TestAuthManager:
     async def test_verify_wrong_token(self, test_db) -> None:
         """Test the verify method with a bad token type."""
         background_tasks = BackgroundTasks()
-        user = await self._register_user(test_db, background_tasks)
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
+        )
         wrong_token = get_token(
             sub=user.id,
             exp=datetime.now(tz=timezone.utc).timestamp() + 10000,
@@ -297,7 +287,9 @@ class TestAuthManager:
     async def test_verify_banned_user(self, test_db) -> None:
         """Test the verify method with a banned user."""
         background_tasks = BackgroundTasks()
-        user = await self._register_user(test_db, background_tasks)
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
+        )
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
         verify_token = get_token(
             sub=user.id,
@@ -312,7 +304,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_verify_user_already_verified(self, test_db) -> None:
         """Test the verify method with a banned user."""
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         verify_token = get_token(
             sub=user.id,
             exp=datetime.now(tz=timezone.utc).timestamp() + 10000,
@@ -352,7 +344,9 @@ class TestAuthManager:
         """Test that verify() successfully updates the database."""
         # Register a new user (defaults to verified=False)
         background_tasks = BackgroundTasks()
-        user = await self._register_user(test_db, background_tasks)
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
+        )
 
         # Get initial user state and verify it's not verified
         user_before = await UserManager.get_user_by_id(user.id, test_db)
@@ -420,7 +414,7 @@ class TestAuthManager:
         )
 
         # Create and ban a user
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
         # Request password reset
@@ -436,7 +430,7 @@ class TestAuthManager:
     async def test_reset_password(self, test_db) -> None:
         """Test successful password reset."""
         # Create a user
-        user_data = await self._register_user(test_db)
+        user_data = await register_and_get_user(test_db, self.test_user)
 
         # Generate reset token
         reset_token = AuthManager.encode_reset_token(user_data)
@@ -504,7 +498,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_reset_password_banned_user(self, test_db) -> None:
         """Test reset_password blocks banned users."""
-        user_data = await self._register_user(test_db)
+        user_data = await register_and_get_user(test_db, self.test_user)
 
         # Generate reset token before banning
         reset_token = AuthManager.encode_reset_token(user_data)
@@ -526,7 +520,7 @@ class TestAuthManager:
     async def test_reset_password_updates_database(self, test_db) -> None:
         """Test that reset_password actually updates the password."""
         # Create a user
-        user_before = await self._register_user(test_db)
+        user_before = await register_and_get_user(test_db, self.test_user)
         old_password_hash = user_before.password
 
         # Generate reset token and reset password
@@ -545,7 +539,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_reset_password_over_limit_password(self, test_db) -> None:
         """Test reset_password rejects passwords over bcrypt's byte limit."""
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         reset_token = AuthManager.encode_reset_token(User(id=user.id))
         password = "x" * (BCRYPT_PASSWORD_MAX_BYTES + 1)
 
@@ -787,7 +781,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_refresh_string_sub_claim(self, test_db) -> None:
         """Test refresh accepts string 'sub' claim and converts to int."""
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(
             {
@@ -809,7 +803,9 @@ class TestAuthManager:
         """Test verify accepts string 'sub' claim and converts to int."""
         # Create unverified user by passing BackgroundTasks
         background_tasks = BackgroundTasks()
-        user = await self._register_user(test_db, background_tasks)
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
+        )
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(
             {
@@ -832,7 +828,7 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_reset_password_string_sub_claim(self, test_db) -> None:
         """Test reset_password accepts string 'sub' and converts to int."""
-        user = await self._register_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
 
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -6,6 +6,7 @@ import jwt
 import pytest
 from fastapi import BackgroundTasks, HTTPException, status
 from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.settings import get_settings, unwrap_secret
 from app.database.helpers import verify_password
@@ -27,6 +28,19 @@ class TestAuthManager:
         "first_name": "Test",
         "last_name": "User",
     }
+
+    async def _register_user(
+        self,
+        test_db: AsyncSession,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> User:
+        """Register the default user and return the persisted model."""
+        await UserManager.register(
+            self.test_user, test_db, background_tasks=background_tasks
+        )
+        return await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
 
     # ------------------------------------------------------------------------ #
     #                           test encoding tokens                           #
@@ -226,9 +240,9 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_refresh_banned_user(self, test_db) -> None:
         """Test the refresh method with a banned user."""
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
-        banned_user_refresh = AuthManager.encode_refresh_token(User(id=1))
+        user = await self._register_user(test_db)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
+        banned_user_refresh = AuthManager.encode_refresh_token(User(id=user.id))
         new_token = None
         with pytest.raises(HTTPException) as exc_info:
             new_token = await AuthManager.refresh(
@@ -245,14 +259,14 @@ class TestAuthManager:
     async def test_verify(self, test_db) -> None:
         """Test the verify method."""
         background_tasks = BackgroundTasks()
-        await UserManager.register(self.test_user, test_db, background_tasks)
-        verify_token = AuthManager.encode_verify_token(User(id=1))
+        user = await self._register_user(test_db, background_tasks)
+        verify_token = AuthManager.encode_verify_token(User(id=user.id))
         with pytest.raises(HTTPException) as exc_info:
             await AuthManager.verify(verify_token, test_db)
         assert exc_info.value.status_code == status.HTTP_200_OK
         assert exc_info.value.detail == ResponseMessages.VERIFICATION_SUCCESS
 
-        user_data = await UserManager.get_user_by_id(1, test_db)
+        user_data = await UserManager.get_user_by_id(user.id, test_db)
         assert user_data.verified is True
 
     @pytest.mark.asyncio
@@ -268,9 +282,9 @@ class TestAuthManager:
     async def test_verify_wrong_token(self, test_db) -> None:
         """Test the verify method with a bad token type."""
         background_tasks = BackgroundTasks()
-        await UserManager.register(self.test_user, test_db, background_tasks)
+        user = await self._register_user(test_db, background_tasks)
         wrong_token = get_token(
-            sub=1,
+            sub=user.id,
             exp=datetime.now(tz=timezone.utc).timestamp() + 10000,
             typ="refresh",
         )
@@ -283,10 +297,10 @@ class TestAuthManager:
     async def test_verify_banned_user(self, test_db) -> None:
         """Test the verify method with a banned user."""
         background_tasks = BackgroundTasks()
-        await UserManager.register(self.test_user, test_db, background_tasks)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await self._register_user(test_db, background_tasks)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
         verify_token = get_token(
-            sub=1,
+            sub=user.id,
             exp=datetime.now(tz=timezone.utc).timestamp() + 10000,
             typ="verify",
         )
@@ -298,9 +312,9 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_verify_user_already_verified(self, test_db) -> None:
         """Test the verify method with a banned user."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self._register_user(test_db)
         verify_token = get_token(
-            sub=1,
+            sub=user.id,
             exp=datetime.now(tz=timezone.utc).timestamp() + 10000,
             typ="verify",
         )
@@ -338,21 +352,21 @@ class TestAuthManager:
         """Test that verify() successfully updates the database."""
         # Register a new user (defaults to verified=False)
         background_tasks = BackgroundTasks()
-        await UserManager.register(self.test_user, test_db, background_tasks)
+        user = await self._register_user(test_db, background_tasks)
 
         # Get initial user state and verify it's not verified
-        user_before = await UserManager.get_user_by_id(1, test_db)
+        user_before = await UserManager.get_user_by_id(user.id, test_db)
         assert user_before.verified is False
 
         # Create and use a verification token
-        verify_token = AuthManager.encode_verify_token(User(id=1))
+        verify_token = AuthManager.encode_verify_token(User(id=user.id))
         with pytest.raises(HTTPException) as exc_info:
             await AuthManager.verify(verify_token, test_db)
         assert exc_info.value.status_code == status.HTTP_200_OK
         assert exc_info.value.detail == ResponseMessages.VERIFICATION_SUCCESS
 
         # Get updated user state and verify the field was updated
-        user_after = await UserManager.get_user_by_id(1, test_db)
+        user_after = await UserManager.get_user_by_id(user.id, test_db)
         assert user_after.verified is True
 
     # ------------------------------------------------------------------------ #
@@ -406,8 +420,8 @@ class TestAuthManager:
         )
 
         # Create and ban a user
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await self._register_user(test_db)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
         # Request password reset
         background_tasks = BackgroundTasks()
@@ -422,8 +436,7 @@ class TestAuthManager:
     async def test_reset_password(self, test_db) -> None:
         """Test successful password reset."""
         # Create a user
-        await UserManager.register(self.test_user, test_db)
-        user_data = await UserManager.get_user_by_id(1, test_db)
+        user_data = await self._register_user(test_db)
 
         # Generate reset token
         reset_token = AuthManager.encode_reset_token(user_data)
@@ -433,7 +446,7 @@ class TestAuthManager:
         await AuthManager.reset_password(reset_token, new_password, test_db)
 
         # Verify password was changed
-        updated_user = await UserManager.get_user_by_id(1, test_db)
+        updated_user = await UserManager.get_user_by_id(user_data.id, test_db)
         assert verify_password(new_password, updated_user.password)
 
     @pytest.mark.asyncio
@@ -491,14 +504,15 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_reset_password_banned_user(self, test_db) -> None:
         """Test reset_password blocks banned users."""
-        await UserManager.register(self.test_user, test_db)
-        user_data = await UserManager.get_user_by_id(1, test_db)
+        user_data = await self._register_user(test_db)
 
         # Generate reset token before banning
         reset_token = AuthManager.encode_reset_token(user_data)
 
         # Ban the user
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        await UserManager.set_ban_status(
+            user_data.id, 666, test_db, banned=True
+        )
 
         # Try to reset password
         with pytest.raises(HTTPException) as exc_info:
@@ -512,8 +526,7 @@ class TestAuthManager:
     async def test_reset_password_updates_database(self, test_db) -> None:
         """Test that reset_password actually updates the password."""
         # Create a user
-        await UserManager.register(self.test_user, test_db)
-        user_before = await UserManager.get_user_by_id(1, test_db)
+        user_before = await self._register_user(test_db)
         old_password_hash = user_before.password
 
         # Generate reset token and reset password
@@ -522,7 +535,7 @@ class TestAuthManager:
         await AuthManager.reset_password(reset_token, new_password, test_db)
 
         # Verify password was actually changed in database
-        user_after = await UserManager.get_user_by_id(1, test_db)
+        user_after = await UserManager.get_user_by_id(user_before.id, test_db)
         assert user_after.password != old_password_hash
         assert verify_password(new_password, user_after.password)
         assert not verify_password(
@@ -532,8 +545,8 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_reset_password_over_limit_password(self, test_db) -> None:
         """Test reset_password rejects passwords over bcrypt's byte limit."""
-        await UserManager.register(self.test_user, test_db)
-        reset_token = AuthManager.encode_reset_token(User(id=1))
+        user = await self._register_user(test_db)
+        reset_token = AuthManager.encode_reset_token(User(id=user.id))
         password = "x" * (BCRYPT_PASSWORD_MAX_BYTES + 1)
 
         with pytest.raises(HTTPException) as exc_info:
@@ -774,12 +787,12 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_refresh_string_sub_claim(self, test_db) -> None:
         """Test refresh accepts string 'sub' claim and converts to int."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self._register_user(test_db)
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(
             {
                 "typ": "refresh",
-                "sub": "1",  # String instead of int
+                "sub": str(user.id),  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 3600,
             },
             unwrap_secret(get_settings().secret_key),
@@ -796,14 +809,12 @@ class TestAuthManager:
         """Test verify accepts string 'sub' claim and converts to int."""
         # Create unverified user by passing BackgroundTasks
         background_tasks = BackgroundTasks()
-        await UserManager.register(
-            self.test_user, test_db, background_tasks=background_tasks
-        )
+        user = await self._register_user(test_db, background_tasks)
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(
             {
                 "typ": "verify",
-                "sub": "1",  # String instead of int
+                "sub": str(user.id),  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 600,
             },
             unwrap_secret(get_settings().secret_key),
@@ -815,19 +826,19 @@ class TestAuthManager:
         # Verify it succeeded with HTTP 200
         assert exc_info.value.status_code == status.HTTP_200_OK
         # Verify the user was marked as verified
-        user = await UserManager.get_user_by_id(1, test_db)
+        user = await UserManager.get_user_by_id(user.id, test_db)
         assert user.verified is True
 
     @pytest.mark.asyncio
     async def test_reset_password_string_sub_claim(self, test_db) -> None:
         """Test reset_password accepts string 'sub' and converts to int."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self._register_user(test_db)
 
         # Create a JWT with string 'sub' claim
         token_with_string_sub = jwt.encode(
             {
                 "typ": "reset",
-                "sub": "1",  # String instead of int
+                "sub": str(user.id),  # String instead of int
                 "exp": datetime.now(tz=timezone.utc).timestamp() + 1800,
             },
             unwrap_secret(get_settings().secret_key),

--- a/tests/unit/test_jwt_auth.py
+++ b/tests/unit/test_jwt_auth.py
@@ -43,7 +43,10 @@ class TestJWTAuth:
 
         assert isinstance(result, User)
         assert result.email == self.test_user["email"]
-        assert result.id == 1
+        user = await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
+        assert result.id == user.id
 
     async def test_jwt_auth_invalid_token(self, test_db, mocker) -> None:
         """Test with an invalid token."""
@@ -135,11 +138,14 @@ class TestJWTAuth:
     async def test_jwt_auth_string_sub_claim(self, test_db, mocker) -> None:
         """Test with a token containing string sub claim."""
         await UserManager.register(self.test_user, test_db)
+        user = await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
         # Create a JWT with string 'sub' instead of int
         token = jwt.encode(
             {
                 "typ": "access",
-                "sub": "1",  # String instead of int
+                "sub": str(user.id),  # String instead of int
                 "exp": datetime.datetime.now(tz=datetime.timezone.utc)
                 + datetime.timedelta(minutes=10),
             },
@@ -158,7 +164,7 @@ class TestJWTAuth:
 
         assert isinstance(result, User)
         assert result.email == self.test_user["email"]
-        assert result.id == 1
+        assert result.id == user.id
 
     async def test_jwt_auth_wrong_signature(self, test_db, mocker) -> None:
         """Test with a token with wrong signature."""
@@ -201,7 +207,10 @@ class TestJWTAuth:
     async def test_jwt_auth_banned_user(self, test_db, mocker) -> None:
         """Test with a banned user."""
         token, _ = await UserManager.register(self.test_user, test_db)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
         mock_req = mocker.patch(self.mock_request_path)
         mock_req.headers = {"Authorization": f"Bearer {token}"}
@@ -223,7 +232,10 @@ class TestJWTAuth:
         token, _ = await UserManager.register(
             self.test_user, test_db, background_tasks=background_tasks
         )
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
         mock_req = mocker.patch(self.mock_request_path)
         mock_req.headers = {"Authorization": f"Bearer {token}"}
@@ -265,9 +277,12 @@ class TestJWTAuth:
         """Test with a deleted user but valid token."""
         # Create user and get token
         token, _ = await UserManager.register(self.test_user, test_db)
+        user = await UserManager.get_user_by_email(
+            self.test_user["email"], test_db
+        )
 
         # Delete the user
-        await UserManager.delete_user(1, test_db)
+        await UserManager.delete_user(user.id, test_db)
         await test_db.flush()
 
         # Try to authenticate with the token

--- a/tests/unit/test_user_manager.py
+++ b/tests/unit/test_user_manager.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.helpers import verify_password
 from app.managers.helpers import BCRYPT_PASSWORD_MAX_BYTES
@@ -27,11 +28,23 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         "last_name": "User",
     }
 
+    async def registered_user(
+        self,
+        test_db: AsyncSession,
+        user_data: dict[str, str] | None = None,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> User:
+        """Register a user and return the persisted model."""
+        data = user_data or self.test_user
+        await UserManager.register(
+            data, test_db, background_tasks=background_tasks
+        )
+        return await UserManager.get_user_by_email(data["email"], test_db)
+
     # ------------------------- Test register method ------------------------- #
     async def test_create_user(self, test_db) -> None:
         """Test creating a user."""
-        await UserManager.register(self.test_user, test_db)
-        new_user = await test_db.get(User, 1)
+        new_user = await self.registered_user(test_db)
 
         assert new_user.email == self.test_user["email"]
         assert new_user.first_name == self.test_user["first_name"]
@@ -121,8 +134,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         self, test_db
     ) -> None:
         """Test user is automatically verified when no 'background_tasks'."""
-        await UserManager.register(self.test_user, test_db)
-        user = await test_db.get(User, 1)
+        user = await self.registered_user(test_db)
 
         assert user.verified is True
 
@@ -132,10 +144,9 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     ) -> None:
         """Test user is not verified when 'background_tasks' IS provided."""
         background_tasks = BackgroundTasks()
-        await UserManager.register(
-            self.test_user, test_db, background_tasks=background_tasks
+        user = await self.registered_user(
+            test_db, background_tasks=background_tasks
         )
-        user = await test_db.get(User, 1)
 
         assert user.verified is False
 
@@ -180,18 +191,18 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_login_user_banned(self, test_db) -> None:
         """Test logging in a user that is banned."""
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await self.registered_user(test_db)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
         with pytest.raises(HTTPException, match=ErrorMessages.AUTH_INVALID):
             await UserManager.login(self.test_user, test_db)
 
     # -------------------------- test delete method -------------------------- #
     async def test_delete_user(self, test_db) -> None:
         """Test deleting a user."""
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.delete_user(1, test_db)
+        new_user = await self.registered_user(test_db)
+        await UserManager.delete_user(new_user.id, test_db)
 
-        user = await test_db.get(User, 1)
+        user = await test_db.get(User, new_user.id)
         assert user is None
 
     async def test_delete_user_not_found(self, test_db) -> None:
@@ -203,19 +214,19 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         """Test that the last admin cannot be deleted."""
         # Register an admin user
         admin_user = self.test_user.copy()
-        await UserManager.register(admin_user, test_db)
+        user = await self.registered_user(test_db, admin_user)
         # Make them an admin
-        await UserManager.change_role(RoleType.admin, 1, test_db)
+        await UserManager.change_role(RoleType.admin, user.id, test_db)
 
         # Try to delete the only admin
         with pytest.raises(HTTPException) as exc_info:
-            await UserManager.delete_user(1, test_db)
+            await UserManager.delete_user(user.id, test_db)
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
         assert exc_info.value.detail == ErrorMessages.CANT_DELETE_LAST_ADMIN
 
         # Verify user still exists
-        user = await test_db.get(User, 1)
+        user = await test_db.get(User, user.id)
         assert user is not None
         assert user.role == RoleType.admin
 
@@ -226,24 +237,24 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         admin_user2 = self.test_user.copy()
         admin_user2["email"] = "admin2@test.com"
 
-        await UserManager.register(admin_user1, test_db)
-        await UserManager.register(admin_user2, test_db)
+        user1 = await self.registered_user(test_db, admin_user1)
+        user2 = await self.registered_user(test_db, admin_user2)
 
         # Make both admins
-        await UserManager.change_role(RoleType.admin, 1, test_db)
-        await UserManager.change_role(RoleType.admin, 2, test_db)
+        await UserManager.change_role(RoleType.admin, user1.id, test_db)
+        await UserManager.change_role(RoleType.admin, user2.id, test_db)
 
         # Delete first admin
-        await UserManager.delete_user(1, test_db)
+        await UserManager.delete_user(user1.id, test_db)
 
         # Verify first admin deleted
-        user1 = await test_db.get(User, 1)
-        assert user1 is None
+        deleted_user = await test_db.get(User, user1.id)
+        assert deleted_user is None
 
         # Verify second admin still exists
-        user2 = await test_db.get(User, 2)
-        assert user2 is not None
-        assert user2.role == RoleType.admin
+        remaining_user = await test_db.get(User, user2.id)
+        assert remaining_user is not None
+        assert remaining_user.role == RoleType.admin
 
     async def test_can_delete_regular_user_as_only_admin(self, test_db) -> None:
         """Test that the only admin can delete regular users."""
@@ -252,21 +263,21 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         regular_user = self.test_user.copy()
         regular_user["email"] = "regular@test.com"
 
-        await UserManager.register(admin_user, test_db)
-        await UserManager.register(regular_user, test_db)
+        admin = await self.registered_user(test_db, admin_user)
+        regular = await self.registered_user(test_db, regular_user)
 
         # Make first user admin
-        await UserManager.change_role(RoleType.admin, 1, test_db)
+        await UserManager.change_role(RoleType.admin, admin.id, test_db)
 
         # Admin deletes regular user (should succeed regardless of admin count)
-        await UserManager.delete_user(2, test_db)
+        await UserManager.delete_user(regular.id, test_db)
 
         # Verify regular user deleted
-        user2 = await test_db.get(User, 2)
+        user2 = await test_db.get(User, regular.id)
         assert user2 is None
 
         # Verify admin still exists
-        admin = await test_db.get(User, 1)
+        admin = await test_db.get(User, admin.id)
         assert admin is not None
         assert admin.role == RoleType.admin
 
@@ -279,34 +290,34 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         admin_user2 = self.test_user.copy()
         admin_user2["email"] = "admin2@test.com"
 
-        await UserManager.register(admin_user1, test_db)
-        await UserManager.register(admin_user2, test_db)
+        admin1 = await self.registered_user(test_db, admin_user1)
+        admin2 = await self.registered_user(test_db, admin_user2)
 
         # Make both admins
-        await UserManager.change_role(RoleType.admin, 1, test_db)
-        await UserManager.change_role(RoleType.admin, 2, test_db)
+        await UserManager.change_role(RoleType.admin, admin1.id, test_db)
+        await UserManager.change_role(RoleType.admin, admin2.id, test_db)
 
         # Admin 1 deletes Admin 2
-        await UserManager.delete_user(2, test_db)
+        await UserManager.delete_user(admin2.id, test_db)
 
         # Verify admin 2 deleted
-        user2 = await test_db.get(User, 2)
+        user2 = await test_db.get(User, admin2.id)
         assert user2 is None
 
         # Verify admin 1 still exists
-        admin1 = await test_db.get(User, 1)
-        assert admin1 is not None
-        assert admin1.role == RoleType.admin
+        remaining_admin = await test_db.get(User, admin1.id)
+        assert remaining_admin is not None
+        assert remaining_admin.role == RoleType.admin
 
     # -------------------------- test update method -------------------------- #
     async def test_update_user(self, test_db) -> None:
         """Test updating a user."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
         edited_user = self.test_user.copy()
         edited_user["first_name"] = "Edited"
 
         updated_user = await UserManager.update_user(
-            1, UserEditRequest(**edited_user), test_db
+            user.id, UserEditRequest(**edited_user), test_db
         )
         assert updated_user is not None
         assert updated_user.first_name == "Edited"
@@ -369,15 +380,15 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # ------------------------ test changing password ------------------------ #
     async def test_change_password(self, test_db) -> None:
         """Test changing a user's password."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
         await UserManager.change_password(
-            1,
+            user.id,
             UserChangePasswordRequest(password="updated_password"),  # noqa: S106
             test_db,
         )
 
-        user = await test_db.get(User, 1)
-        assert user.password != self.test_user["password"]
+        updated_user = await test_db.get(User, user.id)
+        assert updated_user.password != self.test_user["password"]
 
     async def test_change_password_not_found(self, test_db) -> None:
         """Test changing a user's password that doesn't exist."""
@@ -391,21 +402,21 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # -------------------------- test set ban status ------------------------- #
     async def test_ban_user(self, test_db) -> None:
         """Test we can ban or unban a user."""
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        user = await self.registered_user(test_db)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
-        banned_user = await test_db.get(User, 1)
+        banned_user = await test_db.get(User, user.id)
         assert banned_user.banned is True
 
     async def test_unban_user(self, test_db) -> None:
         """Test we can ban or unban a user."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
         # set this user as banned
-        await UserManager.set_ban_status(1, 666, test_db, banned=True)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
-        await UserManager.set_ban_status(1, 666, test_db, banned=False)
+        await UserManager.set_ban_status(user.id, 666, test_db, banned=False)
 
-        banned_user = await test_db.get(User, 1)
+        banned_user = await test_db.get(User, user.id)
         assert banned_user.banned is False
 
     async def test_ban_user_not_found(self, test_db) -> None:
@@ -416,39 +427,45 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     @pytest.mark.parametrize("state", [True, False])
     async def test_cant_ban_user_already_banned(self, test_db, state) -> None:
         """Test we can't ban a user that is already banned/unbanned."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
         if state:
-            await UserManager.set_ban_status(1, 666, test_db, banned=state)
+            await UserManager.set_ban_status(
+                user.id, 666, test_db, banned=state
+            )
 
         with pytest.raises(
             HTTPException, match=ErrorMessages.ALREADY_BANNED_OR_UNBANNED
         ):
-            await UserManager.set_ban_status(1, 666, test_db, banned=state)
+            await UserManager.set_ban_status(
+                user.id, 666, test_db, banned=state
+            )
 
     async def test_cant_ban_self(self, test_db) -> None:
         """Test we can't ban ourselves."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
         with pytest.raises(HTTPException, match=ErrorMessages.CANT_SELF_BAN):
-            await UserManager.set_ban_status(1, 1, test_db, banned=True)
+            await UserManager.set_ban_status(
+                user.id, user.id, test_db, banned=True
+            )
 
     # ------------------------- test change user role ------------------------ #
     async def test_change_user_role_to_admin(self, test_db) -> None:
         """Test we can change a user's role to admin."""
-        await UserManager.register(self.test_user, test_db)
-        await UserManager.change_role(RoleType.admin, 1, test_db)
+        user = await self.registered_user(test_db)
+        await UserManager.change_role(RoleType.admin, user.id, test_db)
 
-        user_data = await test_db.get(User, 1)
+        user_data = await test_db.get(User, user.id)
 
         assert user_data.role == RoleType.admin
 
     # ----------------------- test the helper functions ---------------------- #
     async def test_get_user_by_id(self, test_db) -> None:
         """Ensure we can get a user by their id."""
-        await UserManager.register(self.test_user, test_db)
-        user_data = await UserManager.get_user_by_id(1, test_db)
+        user = await self.registered_user(test_db)
+        user_data = await UserManager.get_user_by_id(user.id, test_db)
 
         assert user_data is not None
-        assert user_data.id == 1
+        assert user_data.id == user.id
 
     async def test_get_user_by_id_not_found(self, test_db) -> None:
         """Ensure we get None if the user doesn't exist."""
@@ -465,7 +482,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
         assert user_data is not None
         assert user_data.email == self.test_user["email"]
-        assert user_data.id == 1
+        assert user_data.id is not None
 
     async def test_get_user_by_email_not_found(self, test_db) -> None:
         """Ensure we get None if the user with email doesn't exist."""
@@ -555,11 +572,11 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_change_password_with_invalid_format(self, test_db) -> None:
         """Test changing password with an invalid format."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
 
         with pytest.raises(HTTPException) as exc_info:
             await UserManager.change_password(
-                1,
+                user.id,
                 UserChangePasswordRequest(password=""),  # Empty password
                 test_db,
             )
@@ -569,14 +586,14 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_change_password_with_none_password(self, test_db) -> None:
         """Test changing password with a None value."""
-        await UserManager.register(self.test_user, test_db)
+        user = await self.registered_user(test_db)
 
         # Create request without password to simulate None
         request = UserChangePasswordRequest.model_construct()
         request.password = None  # type: ignore
 
         with pytest.raises(HTTPException) as exc_info:
-            await UserManager.change_password(1, request, test_db)
+            await UserManager.change_password(user.id, request, test_db)
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
         assert exc_info.value.detail == ErrorMessages.PASSWORD_INVALID

--- a/tests/unit/test_user_manager.py
+++ b/tests/unit/test_user_manager.py
@@ -2,7 +2,6 @@
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException, status
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.helpers import verify_password
 from app.managers.helpers import BCRYPT_PASSWORD_MAX_BYTES
@@ -14,6 +13,7 @@ from app.schemas.request.user import (
     UserChangePasswordRequest,
     UserEditRequest,
 )
+from tests.helpers import register_and_get_user
 
 
 @pytest.mark.unit
@@ -28,23 +28,10 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         "last_name": "User",
     }
 
-    async def registered_user(
-        self,
-        test_db: AsyncSession,
-        user_data: dict[str, str] | None = None,
-        background_tasks: BackgroundTasks | None = None,
-    ) -> User:
-        """Register a user and return the persisted model."""
-        data = user_data or self.test_user
-        await UserManager.register(
-            data, test_db, background_tasks=background_tasks
-        )
-        return await UserManager.get_user_by_email(data["email"], test_db)
-
     # ------------------------- Test register method ------------------------- #
     async def test_create_user(self, test_db) -> None:
         """Test creating a user."""
-        new_user = await self.registered_user(test_db)
+        new_user = await register_and_get_user(test_db, self.test_user)
 
         assert new_user.email == self.test_user["email"]
         assert new_user.first_name == self.test_user["first_name"]
@@ -134,7 +121,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         self, test_db
     ) -> None:
         """Test user is automatically verified when no 'background_tasks'."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
 
         assert user.verified is True
 
@@ -144,8 +131,8 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     ) -> None:
         """Test user is not verified when 'background_tasks' IS provided."""
         background_tasks = BackgroundTasks()
-        user = await self.registered_user(
-            test_db, background_tasks=background_tasks
+        user = await register_and_get_user(
+            test_db, self.test_user, background_tasks
         )
 
         assert user.verified is False
@@ -191,7 +178,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_login_user_banned(self, test_db) -> None:
         """Test logging in a user that is banned."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
         with pytest.raises(HTTPException, match=ErrorMessages.AUTH_INVALID):
             await UserManager.login(self.test_user, test_db)
@@ -199,7 +186,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # -------------------------- test delete method -------------------------- #
     async def test_delete_user(self, test_db) -> None:
         """Test deleting a user."""
-        new_user = await self.registered_user(test_db)
+        new_user = await register_and_get_user(test_db, self.test_user)
         await UserManager.delete_user(new_user.id, test_db)
 
         user = await test_db.get(User, new_user.id)
@@ -214,7 +201,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         """Test that the last admin cannot be deleted."""
         # Register an admin user
         admin_user = self.test_user.copy()
-        user = await self.registered_user(test_db, admin_user)
+        user = await register_and_get_user(test_db, admin_user)
         # Make them an admin
         await UserManager.change_role(RoleType.admin, user.id, test_db)
 
@@ -237,8 +224,8 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         admin_user2 = self.test_user.copy()
         admin_user2["email"] = "admin2@test.com"
 
-        user1 = await self.registered_user(test_db, admin_user1)
-        user2 = await self.registered_user(test_db, admin_user2)
+        user1 = await register_and_get_user(test_db, admin_user1)
+        user2 = await register_and_get_user(test_db, admin_user2)
 
         # Make both admins
         await UserManager.change_role(RoleType.admin, user1.id, test_db)
@@ -263,8 +250,8 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         regular_user = self.test_user.copy()
         regular_user["email"] = "regular@test.com"
 
-        admin = await self.registered_user(test_db, admin_user)
-        regular = await self.registered_user(test_db, regular_user)
+        admin = await register_and_get_user(test_db, admin_user)
+        regular = await register_and_get_user(test_db, regular_user)
 
         # Make first user admin
         await UserManager.change_role(RoleType.admin, admin.id, test_db)
@@ -290,8 +277,8 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
         admin_user2 = self.test_user.copy()
         admin_user2["email"] = "admin2@test.com"
 
-        admin1 = await self.registered_user(test_db, admin_user1)
-        admin2 = await self.registered_user(test_db, admin_user2)
+        admin1 = await register_and_get_user(test_db, admin_user1)
+        admin2 = await register_and_get_user(test_db, admin_user2)
 
         # Make both admins
         await UserManager.change_role(RoleType.admin, admin1.id, test_db)
@@ -312,7 +299,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # -------------------------- test update method -------------------------- #
     async def test_update_user(self, test_db) -> None:
         """Test updating a user."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         edited_user = self.test_user.copy()
         edited_user["first_name"] = "Edited"
 
@@ -380,7 +367,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # ------------------------ test changing password ------------------------ #
     async def test_change_password(self, test_db) -> None:
         """Test changing a user's password."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.change_password(
             user.id,
             UserChangePasswordRequest(password="updated_password"),  # noqa: S106
@@ -402,7 +389,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # -------------------------- test set ban status ------------------------- #
     async def test_ban_user(self, test_db) -> None:
         """Test we can ban or unban a user."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
         banned_user = await test_db.get(User, user.id)
@@ -410,7 +397,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_unban_user(self, test_db) -> None:
         """Test we can ban or unban a user."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         # set this user as banned
         await UserManager.set_ban_status(user.id, 666, test_db, banned=True)
 
@@ -427,7 +414,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     @pytest.mark.parametrize("state", [True, False])
     async def test_cant_ban_user_already_banned(self, test_db, state) -> None:
         """Test we can't ban a user that is already banned/unbanned."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         if state:
             await UserManager.set_ban_status(
                 user.id, 666, test_db, banned=state
@@ -442,7 +429,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_cant_ban_self(self, test_db) -> None:
         """Test we can't ban ourselves."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         with pytest.raises(HTTPException, match=ErrorMessages.CANT_SELF_BAN):
             await UserManager.set_ban_status(
                 user.id, user.id, test_db, banned=True
@@ -451,7 +438,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # ------------------------- test change user role ------------------------ #
     async def test_change_user_role_to_admin(self, test_db) -> None:
         """Test we can change a user's role to admin."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         await UserManager.change_role(RoleType.admin, user.id, test_db)
 
         user_data = await test_db.get(User, user.id)
@@ -461,7 +448,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
     # ----------------------- test the helper functions ---------------------- #
     async def test_get_user_by_id(self, test_db) -> None:
         """Ensure we can get a user by their id."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
         user_data = await UserManager.get_user_by_id(user.id, test_db)
 
         assert user_data is not None
@@ -572,7 +559,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_change_password_with_invalid_format(self, test_db) -> None:
         """Test changing password with an invalid format."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
 
         with pytest.raises(HTTPException) as exc_info:
             await UserManager.change_password(
@@ -586,7 +573,7 @@ class TestUserManager:  # pylint: disable=too-many-public-methods
 
     async def test_change_password_with_none_password(self, test_db) -> None:
         """Test changing password with a None value."""
-        user = await self.registered_user(test_db)
+        user = await register_and_get_user(test_db, self.test_user)
 
         # Create request without password to simulate None
         request = UserChangePasswordRequest.model_construct()

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiosmtpd"
 version = "1.4.6"
@@ -153,6 +157,7 @@ dev = [
     { name = "pytest-reverse" },
     { name = "pytest-sugar" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-passlib" },
@@ -222,6 +227,7 @@ dev = [
     { name = "pytest-reverse", specifier = ">=1.8.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.7.2" },
     { name = "ty", specifier = ">=0.0.5" },
     { name = "types-passlib", specifier = ">=1.7.7.20240819" },
@@ -937,6 +943,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2807,6 +2822,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/72/a2a1e81f1b272ddd9a1848af4959c87c39aa95c0bbfb3007cacb86c47fa9/pytest_watcher-0.4.3.tar.gz", hash = "sha256:0cb0e4661648c8c0ff2b2d25efa5a8e421784b9e4c60fcecbf9b7c30b2d731b3", size = 10386, upload-time = "2024-08-28T17:37:46.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/3a/c44a76c6bb5e9e896d9707fb1c704a31a0136950dec9514373ced0684d56/pytest_watcher-0.4.3-py3-none-any.whl", hash = "sha256:d59b1e1396f33a65ea4949b713d6884637755d641646960056a90b267c3460f9", size = 11852, upload-time = "2024-08-28T17:37:45.731Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds pytest-xdist as a first-class part of the test workflow and refactors the
database harness so pytest creates the schema once per session while isolating
each test inside a rolled-back transaction.

## Details

- Runs pytest with logical workers by default.
- Replaces per-test schema drops with transactional async fixtures using
  savepoints and NullPool.
- Updates tests to use actual generated IDs instead of assuming fresh database
  sequences.
- Adds coverage for successful admin token authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled parallel test execution by adding xdist to dev tooling and updated test runner options.
  * Updated development test tooling configuration.

* **Tests**
  * Overhauled test database lifecycle and fixtures for async, transactional isolation and reliable per-test cleanup.
  * Added helpers to register and fetch test users; removed hard-coded user IDs across tests.
  * Refactored multiple unit and integration tests for consistent session usage and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->