### PR TITLE
Set uv dependency cooldown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
         additional_dependencies:
           - pydantic
           - sqladmin
+          - types-Markdown
           - types-redis
 
   - repo: https://github.com/astral-sh/uv-pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,15 @@ Run the following command to install the required dependencies:
 uv sync
 ```
 
+> [!NOTE]
+> The project sets `exclude-newer = "7 days"` for `uv` in `pyproject.toml`.
+> This intentionally ignores packages uploaded in the last seven days, giving
+> new releases a short settling period before they can enter the lock file or
+> generated requirements files. This reduces the chance of pulling in a
+> compromised, yanked, or accidentally broken release. If your project needs
+> immediate dependency updates, remove the `exclude-newer` setting from
+> `[tool.uv]` and regenerate the lock and requirements files.
+
 You then need to activate the virtual environment:
 
 ```terminal
@@ -151,6 +160,9 @@ This will ensure that all code meets the required linting standard before being
 committed. It will also automatically generate updated `requirements.txt` and
 `requirements-dev.txt` files if required. Note that generating these files will
 cause the commit to fail, so you can add the new files to your git stage.
+
+The `uv-lock` and `uv-export` hooks use the same project-level `uv` cooldown
+described in [Install Dependencies](#install-dependencies).
 
 !!! important
 

--- a/docs/hooks/__init__.py
+++ b/docs/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Define some custom hooks for Mkdocs."""

--- a/docs/hooks/google_style_notes.py
+++ b/docs/hooks/google_style_notes.py
@@ -1,0 +1,70 @@
+"""Markdown extension for MkDocs to support GitHub-style callouts."""
+
+import re
+
+from markdown import Markdown
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+
+CALLOUT_PATTERN = re.compile(
+    r"^> \[!(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\][ \t]*\n"
+    r"((?:>.*(?:\n|$))*)",
+    flags=re.MULTILINE,
+)
+
+CALLOUT_TYPES = {
+    "NOTE": "note",
+    "TIP": "tip",
+    "WARNING": "warning",
+    "IMPORTANT": "info",
+    "CAUTION": "danger",
+}
+
+
+def convert_github_callouts(markdown: str) -> str:
+    """Convert GitHub-style callouts to MkDocs admonitions."""
+
+    def replace_callout(match: re.Match[str]) -> str:
+        """Replace one callout block."""
+        original_type = match.group(1)
+        admonition_type = CALLOUT_TYPES[original_type]
+        title = original_type.title()
+        content_lines = [
+            re.sub(r"^> ?", "", line).rstrip()
+            for line in match.group(2).splitlines()
+        ]
+
+        while content_lines and not content_lines[0]:
+            content_lines.pop(0)
+
+        indented_content = "\n".join(
+            f"    {line}" if line else "" for line in content_lines
+        )
+        return f'!!! {admonition_type} "{title}"\n\n{indented_content}\n'
+
+    return CALLOUT_PATTERN.sub(replace_callout, markdown)
+
+
+class GithubCalloutPreprocessor(Preprocessor):
+    """Convert GitHub-style callouts after snippet expansion."""
+
+    def run(self, lines: list[str]) -> list[str]:
+        """Process Markdown lines."""
+        return convert_github_callouts("\n".join(lines)).split("\n")
+
+
+class GithubCalloutExtension(Extension):
+    """Register the GitHub callout preprocessor."""
+
+    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
+        """Register the preprocessor after pymdownx.snippets."""
+        md.preprocessors.register(
+            GithubCalloutPreprocessor(md),
+            "github_callouts",
+            31,
+        )
+
+
+def makeExtension(**kwargs: object) -> GithubCalloutExtension:  # noqa: N802
+    """Return the Markdown extension."""
+    return GithubCalloutExtension(**kwargs)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,7 +270,7 @@ Restart the application.
    git commit --no-verify
    ```
 
-### uv or prek Will Not Pick Up the Latest Package
+### uv or prek Will Not Pick Up New Package Releases
 
 This template sets `exclude-newer = "7 days"` in `pyproject.toml`, so `uv`
 ignores packages uploaded in the last seven days. The `prek` dependency hooks use

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,6 +270,25 @@ Restart the application.
    git commit --no-verify
    ```
 
+### uv or prek Will Not Pick Up the Latest Package
+
+This template sets `exclude-newer = "7 days"` in `pyproject.toml`, so `uv`
+ignores packages uploaded in the last seven days. The `prek` dependency hooks use
+the same project setting when they update `uv.lock`, `requirements.txt`, and
+`requirements-dev.txt`.
+
+This is intentional: it gives newly published packages a short settling period
+before they are allowed into the project, reducing the risk from compromised,
+yanked, or accidentally broken releases.
+
+If you need the newest packages immediately, remove the `exclude-newer` setting
+from the `[tool.uv]` section in `pyproject.toml`, then run:
+
+```bash
+uv lock
+poe pre
+```
+
 ## Still Having Issues?
 
 If your problem isn't listed here:

--- a/docs/usage/configuration/setup.md
+++ b/docs/usage/configuration/setup.md
@@ -36,6 +36,18 @@ all that is needed.
 $ uv sync
 ```
 
+!!! note "Dependency update cooldown"
+
+    This template sets `exclude-newer = "7 days"` in `pyproject.toml`. This
+    tells `uv` to ignore packages uploaded in the last seven days, which gives
+    newly published releases a short settling period before they can enter your
+    lock file or generated requirements files. This helps reduce exposure to
+    compromised, yanked, or accidentally broken package releases.
+
+    If your project needs immediate access to newly released packages, remove
+    the `exclude-newer` setting from the `[tool.uv]` section in `pyproject.toml`
+    and run `uv lock` again.
+
 If you do not (or cannot) have `uv` installed, I have provided an
 auto-generated`requirements.txt` in the project root which you can use as
 normal:

--- a/docs/usage/configuration/setup.md
+++ b/docs/usage/configuration/setup.md
@@ -46,7 +46,7 @@ $ uv sync
 
     If your project needs immediate access to newly released packages, remove
     the `exclude-newer` setting from the `[tool.uv]` section in `pyproject.toml`
-    and run `uv lock` again.
+    and run `poe pre` to update the lock file and generated requirements files.
 
 If you do not (or cannot) have `uv` installed, I have provided an
 auto-generated`requirements.txt` in the project root which you can use as

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ markdown_extensions:
   - admonition
   - footnotes
   - pymdownx.snippets
+  - docs.hooks.google_style_notes
   - pymdownx.superfences
   - md_in_html
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ build-backend = "uv_build"
 module-root = ""
 module-name = "app"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [dependency-groups]
 dev = [
   "aiosmtpd>=1.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,12 @@ api-admin = "app.api_admin:app"
 requires = ["uv_build>=0.11.14,<0.12.0"]
 build-backend = "uv_build"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.build-backend]
 module-root = ""
 module-name = "app"
-
-[tool.uv]
-exclude-newer = "7 days"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
   "prek>=0.2.24",
   "types-redis>=4.6.0.20241004",
   "pytest-xdist>=3.8.0",
+  "types-markdown>=3.10.2.20260518",
 ]
 
 [tool.uv.sources]
@@ -221,7 +222,7 @@ keep-runtime-typing = true
 
 [tool.mypy]
 python_version = "3.10"
-exclude = ["app/migrations/"]
+exclude = ["app/migrations/", "site/"]
 
 [[tool.mypy.overrides]]
 disable_error_code = ["method-assign", "no-untyped-def", "attr-defined"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -462,6 +462,7 @@ typer==0.25.1
     #   github-changelog-md
 types-cffi==1.17.0.20250915
     # via types-pyopenssl
+types-markdown==3.10.2.20260518
 types-passlib==1.7.7.20241221
 types-pyopenssl==24.1.0.20240722
     # via types-redis

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-markdown" },
     { name = "types-passlib" },
     { name = "types-redis" },
 ]
@@ -230,6 +231,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.7.2" },
     { name = "ty", specifier = ">=0.0.5" },
+    { name = "types-markdown", specifier = ">=3.10.2.20260518" },
     { name = "types-passlib", specifier = ">=1.7.7.20240819" },
     { name = "types-redis", specifier = ">=4.6.0.20241004" },
 ]
@@ -3621,6 +3623,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/98/ea454cea03e5f351323af6a482c65924f3c26c515efd9090dede58f2b4b6/types_cffi-1.17.0.20250915.tar.gz", hash = "sha256:4362e20368f78dabd5c56bca8004752cc890e07a71605d9e0d9e069dbaac8c06", size = 17229, upload-time = "2025-09-15T03:01:25.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/ec/092f2b74b49ec4855cdb53050deb9699f7105b8fda6fe034c0781b8687f3/types_cffi-1.17.0.20250915-py3-none-any.whl", hash = "sha256:cef4af1116c83359c11bb4269283c50f0688e9fc1d7f0eeb390f3661546da52c", size = 20112, upload-time = "2025-09-15T03:01:24.187Z" },
+]
+
+[[package]]
+name = "types-markdown"
+version = "3.10.2.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/82/c605b9c9cfa244922449af20b93f8c4ecdc936b926d3340830036e0f87f1/types_markdown-3.10.2.20260518.tar.gz", hash = "sha256:206b044dd55a02ed66dfb9cfc02b1e500005d60370834cee5b41d26a3d8f0f72", size = 19865, upload-time = "2026-05-18T06:01:32.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/db/fa5eef03f646f507d078a382ff8b239871ea847460f79effcfc44977865d/types_markdown-3.10.2.20260518-py3-none-any.whl", hash = "sha256:146fa9997a7d3aa3de1e3a51c56f3875d3947b7c545e58691e79f65fb56a663f", size = 25821, upload-time = "2026-05-18T06:01:31.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a project-level uv dependency cooldown so package resolution ignores releases from the last seven days by default.

This gives newly published packages a short settling period before they can enter the lock file or generated requirements files, reducing exposure to compromised, yanked, or accidentally broken releases.

The docs explain the policy, how it affects prek dependency hooks, and how to remove it when a project needs immediate dependency updates. MkDocs now renders GitHub-style callouts from the root `CONTRIBUTING.md` when that file is included through the docs snippet wrapper.

Related: no linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs now convert GitHub-style callouts into formatted admonitions for clearer notes.

* **Documentation**
  * Added guidance on the 7‑day dependency “update cooldown” and steps to fetch newest packages immediately.
  * New troubleshooting and setup notes clarifying cooldown behaviour.

* **Chores**
  * Added Markdown type stubs to development dependencies and updated tooling/configuration to support checks and docs.
* **Chores**
  * Enabled the new docs extension and updated pre‑commit tooling to include required stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->