### PR TITLE
deps: upgrade pytest to 9.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "poethepoet>=0.48.0",
   "pyfakefs>=6.2.0",
   "pymarkdownlnt>=0.9.39",
-  "pytest==9.0.3",
+    "pytest==9.1.1",
   "pytest-asyncio>=1.4.0",
   "pytest-clarity>=1.0.1",
   "pytest-cov>=7.1.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -111,7 +111,7 @@ pyjwt==2.13.0
 pymarkdownlnt==0.9.39
 pymdown-extensions==11.0.1
 pynacl==1.6.2
-pytest==9.0.3
+pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-clarity==1.0.1
 pytest-cov==7.1.0

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock
@@ -339,16 +340,12 @@ class TestLogConfig:
 
         mock_logger_add = mocker.patch("app.config.log_config.logger.add")
         mocker.patch("app.config.log_config.logger.remove")
-        mock_uvicorn_logger = mocker.Mock()
-        mock_get_logger = mocker.patch(
-            "app.config.log_config.logging.getLogger",
-            return_value=mock_uvicorn_logger,
-        )
+        uvicorn_logger = logging.getLogger("uvicorn")
+        mock_uvicorn_info = mocker.patch.object(uvicorn_logger, "info")
 
         setup_logging()
 
-        mock_get_logger.assert_called_once_with("uvicorn")
-        mock_uvicorn_logger.info.assert_called_once_with(
+        mock_uvicorn_info.assert_called_once_with(
             "Loguru enqueue disabled because uvicorn reload is enabled."
         )
         assert mock_logger_add.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,7 @@ dev = [
     { name = "pygments", specifier = ">=2.21.0" },
     { name = "pymarkdownlnt", specifier = ">=0.9.39" },
     { name = "pymdown-extensions", specifier = ">=11.0.1" },
-    { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -2720,7 +2720,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2731,9 +2731,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade pytest from 9.0.3 to 9.1.1 while retaining pytest-xdist 3.8.0 and Python 3.10 through 3.14 support
- isolate the Uvicorn reload logging test by mocking only the named logger method
- regenerate the development dependency export without unrelated resolver movement

Pytest 9.1 captures non-propagating loggers. Avoiding a mock of the shared standard-library logger lookup prevents that capture behavior from encountering test-mutated global logging state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage of reload-mode logging behaviour.
  * Updated logging checks to reflect the application’s actual server logger.

* **Chores**
  * Updated the development testing framework to version 9.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->