### PR TITLE
ci: add python 3.15 to the test matrix as non-blocking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,20 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Prepare experimental Python 3.15 environment
+        if: matrix.python-version == '3.15'
+        run: |
+          uv venv --python 3.15 --no-project
+          uv pip install -r pyproject.toml --all-extras --group dev
+
       - name: Run tests
-        # For example, using `pytest`
+        if: matrix.python-version != '3.15'
         run: uv run --all-extras -p ${{ matrix.python-version }} pytest tests
           --cov-report=xml
+
+      - name: Run tests on experimental Python
+        if: matrix.python-version == '3.15'
+        run: .venv/bin/python -m pytest tests --cov-report=xml
 
       - name: Run codacy-coverage-reporter
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     env:
       SKIP_COVERAGE_UPLOAD: false
       SECRET_KEY: test_jwt_secret_key_for_pytest_at_least_32_characters_long_abc123
@@ -19,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 
     services:
       postgres:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Prepare experimental Python 3.15 environment
         if: matrix.python-version == '3.15'
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: |
           uv venv --python 3.15 --no-project
           uv pip install -r pyproject.toml --all-extras --group dev


### PR DESCRIPTION
Add Python 3.15 (currently at rc1) to the CI test matrix. 

This is non-blocking so a failure in 3.15 will not fail the CI. Other versions in the matrix will still fail.

> [!NOTE]
>
> currently `rtoml` fails under python 31.5 so leaving this unmerged until that is fixed