### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +60,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,6 +73,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,14 +20,20 @@ on:
   schedule:
     - cron: '29 12 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: read # Read workflow metadata required by CodeQL.
       contents: read
-      security-events: write
+      security-events: write # Upload CodeQL analysis results.
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,11 +7,16 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   dependency-review:
+    name: Dependency review
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,10 +9,12 @@ jobs:
     name: mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,6 +2,13 @@ name: Type Checking
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   mypy:
     # uncomment the line before to disable this job if needed.

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -5,5 +5,7 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: j178/prek-action@v3.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,8 +1,16 @@
 name: Prek checks
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   prek:
+    name: Prek
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,8 +6,10 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           args: " check --output-format=concise"
       - run: ruff format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,8 +2,16 @@ name: Linting
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   ruff:
+    name: Ruff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:18
+        image: postgres:18.6@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -35,10 +35,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -55,7 +57,7 @@ jobs:
         env:
           CODACY_CONFIGURED: ${{ secrets.CODACY_PROJECT_TOKEN }}
         if: ${{ env.CODACY_CONFIGURED != ''}}
-        uses: codacy/codacy-coverage-reporter-action@v1
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         continue-on-error: true
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,16 @@ on:
     branches: ["main", "develop"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
+    name: Python tests
     runs-on: ubuntu-latest
     env:
       SKIP_COVERAGE_UPLOAD: false
@@ -46,11 +54,15 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Run tests
         # For example, using `pytest`
-        run: uv run --all-extras -p ${{ matrix.python-version }} pytest tests
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv run --all-extras -p "$PYTHON_VERSION" pytest tests
           --cov-report=xml
 
       - name: Run codacy-coverage-reporter

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          version: 1.29.0
+          collect: workflows,actions
+          persona: pedantic
+          online-audits: true
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          version: 1.29.0
+          version: 1.29.0 # Keep in sync with the pyproject.toml dev dependency.
           collect: workflows,actions
           persona: pedantic
           online-audits: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,11 +192,14 @@ As before, this will generate updated `requirements.txt` and
     regularly to ensure the dependency files are updated and that the linters all
     pass.
 
-#### GitHub CI Action
+#### GitHub CI checks
 
 The checks in this pre-commit hook are also automatically run for each commit
 pushed to GitHub and for Pull Requests. This is controlled by the
-`~/.github/workflows/prek.yml` configuration file.
+`.github/workflows/prek.yml` configuration file. GitHub Actions also runs the
+test suite, type checking, and security checks. See the
+[Continuous Integration](https://fastapi-template.seapagan.net/development/ci/)
+guide for the corresponding local commands and Zizmor configuration.
 
 ## Testing
 

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -1,0 +1,82 @@
+# Continuous Integration
+
+GitHub Actions checks every pull request and changes pushed to the main
+development branches. These checks cover code quality, typing, tests,
+dependencies, and the security of the GitHub Actions configuration itself.
+
+## Run CI Checks Locally
+
+Run the relevant checks before opening or updating a pull request:
+
+```console
+$ poe ruff
+$ poe mypy
+$ poe test
+$ poe pre
+$ poe zizmor
+```
+
+`poe pre` runs the repository's configured pre-commit hooks against all files.
+The other tasks are useful as narrower checks while developing. Some hosted
+checks, including CodeQL and dependency review, have no direct local
+equivalent.
+
+## Audit GitHub Actions with Zizmor
+
+[Zizmor](https://docs.zizmor.sh/){:target="_blank"} audits GitHub Actions
+workflows and action definitions for security issues. Install it as a standalone
+tool if it is not already available:
+
+```console
+$ uv tool install zizmor
+```
+
+Run the repository's configured audit with:
+
+```console
+$ poe zizmor
+```
+
+The task scans workflow and action definitions using Zizmor's `pedantic`
+persona. The dedicated GitHub Actions workflow applies the same policy and runs
+online audits.
+
+### Enable Online Audits Locally
+
+The Zizmor command-line tool runs offline unless a GitHub API token is
+available. Set any one of these equivalent environment variables to enable
+online audits:
+
+| Variable | Typical use |
+| --- | --- |
+| `ZIZMOR_GITHUB_TOKEN` | Tool-specific token; recommended for local use |
+| `GH_TOKEN` | Token shared with the GitHub CLI |
+| `GITHUB_TOKEN` | General GitHub automation token |
+
+For example, reuse the token managed by the authenticated GitHub CLI session:
+
+```console
+$ export ZIZMOR_GITHUB_TOKEN="$(gh auth token)"
+$ poe zizmor
+```
+
+The token only needs read access to repository contents. Keep it out of the
+repository and application `.env` files.
+
+Set `ZIZMOR_OFFLINE=1` to force offline mode even when a token is available.
+Set `ZIZMOR_NO_ONLINE_AUDITS=1` to allow remote inputs to be fetched while
+skipping audits that require GitHub API access.
+
+The hosted workflow does not require a separately configured repository secret.
+The Zizmor action uses the job's automatically provided GitHub token and the
+workflow grants only `contents: read` permission.
+
+### Personas and Suppressed Findings
+
+The `pedantic` persona is the repository's local and hosted CI policy. Zizmor's
+`auditor` persona includes additional review-oriented findings that require
+manual assessment and may not be appropriate as routine CI failures.
+
+Consequently, a successful pedantic run can report suppressed findings. This
+means those findings belong to a different persona; it does not mean they were
+disabled with inline comments or configuration.

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -24,12 +24,10 @@ equivalent.
 ## Audit GitHub Actions with Zizmor
 
 [Zizmor](https://docs.zizmor.sh/){:target="_blank"} audits GitHub Actions
-workflows and action definitions for security issues. Install it as a standalone
-tool if it is not already available:
-
-```console
-$ uv tool install zizmor
-```
+workflows and action definitions for security issues. Zizmor is pinned as a
+development dependency so that local and hosted audits use the same version. It
+is installed by either `uv sync` or `pip install -r requirements-dev.txt`; no
+separate tool installation is required.
 
 Run the repository's configured audit with:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Metadata: customization/meta.md
       - Templates: customization/templates.md
   - Development and Testing:
+      - Continuous Integration: development/ci.md
       - With a Local Server: development/local.md
       - With Docker: development/docker.md
       - Documentation: development/documentation.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
   "types-redis>=4.6.0.20241004",
   "pytest-xdist>=3.8.0",
   "types-markdown>=3.10.2.20260712",
+  "zizmor==1.29.0", # Keep in sync with .github/workflows/zizmor.yml.
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "poethepoet>=0.48.0",
   "pyfakefs>=6.2.0",
   "pymarkdownlnt>=0.9.39",
-    "pytest==9.1.1",
+  "pytest==9.1.1",
   "pytest-asyncio>=1.4.0",
   "pytest-clarity>=1.0.1",
   "pytest-cov>=7.1.0",
@@ -119,6 +119,12 @@ test.cmd = "pytest"
 "test:integration".cmd = "pytest -m integration"
 "test:skipped".cmd = "pytest --quiet --collect-only -m skip --no-cov"
 "test:skipped".help = "Show skipped tests without running all tests"
+
+# zizmor task to check github actions
+# currently the deafult invocation fails d/t our prek config. We ignore the prek
+# config check for now until the fixed version is released.
+zizmor.help = "Check all GitHub actions using 'zizmor'"
+zizmor.cmd = "zizmor --persona=pedantic --collect=workflows,actions ."
 
 # Add 'ty' type checker - this is still beta software and has false positives
 # compared to 'mypy', but suspect it will exentually replace it.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -173,3 +173,4 @@ websockets==15.0
 win32-setctime==1.2.0 ; sys_platform == 'win32'
 wrapt==1.17.2
 wtforms==3.1.2
+zizmor==1.29.0

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,7 @@ dev = [
     { name = "types-markdown" },
     { name = "types-passlib" },
     { name = "types-redis" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -229,6 +230,7 @@ dev = [
     { name = "types-markdown", specifier = ">=3.10.2.20260712" },
     { name = "types-passlib", specifier = ">=1.7.7.20260211" },
     { name = "types-redis", specifier = ">=4.6.0.20241004" },
+    { name = "zizmor", specifier = "==1.29.0" },
 ]
 
 [[package]]
@@ -4080,4 +4082,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/c7/96d10183c3470f1836846f7b9527d6cb0b6c2226ebca40f36fa29f23de60/wtforms-3.1.2.tar.gz", hash = "sha256:f8d76180d7239c94c6322f7990ae1216dae3659b7aa1cee94b6318bdffb474b9", size = 134705, upload-time = "2024-01-06T07:52:41.075Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/19/c3232f35e24dccfad372e9f341c4f3a1166ae7c66e4e1351a9467c921cc1/wtforms-3.1.2-py3-none-any.whl", hash = "sha256:bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07", size = 145961, upload-time = "2024-01-06T07:52:43.023Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
Adds a Poe task and dedicated CI workflow for pedantic Zizmor audits. Hardens the existing GitHub Actions workflows with immutable dependency pins, disabled checkout credential persistence, least-privilege permissions, concurrency limits, named jobs, safe matrix handling, and a pinned PostgreSQL service image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security auditing for GitHub Actions workflows.
  * Added local Zizmor checks for workflow security validation.

* **Documentation**
  * Added a Continuous Integration guide covering automated checks and local commands.
  * Updated contributor guidance and documentation navigation.

* **Chores**
  * Improved CI reliability and security with stricter permissions, protected credentials, pinned actions, run cancellation, and reproducible service versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->